### PR TITLE
Инфраструктура интеграционных тестов для Infrastructure-репозиториев

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -92,6 +92,17 @@ jobs:
           sudo install -m 0755 actionlint /usr/local/bin/actionlint
       - run: make repo-quality
 
+  backend-integration:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+      - run: cp .env.example .env
+      - run: make backend-integration
+      - if: always()
+        run: docker compose down --volumes
+
   api-smoke:
     runs-on: ubuntu-latest
     steps:

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 .DEFAULT_GOAL := help
 
-.PHONY: help init up down setup check backend-quality coverage frontend-quality frontend-coverage e2e repo-quality smoke demo-bundle frontend-build schema-diagram schema-diagram-check
+.PHONY: help init up down setup check backend-quality coverage backend-integration frontend-quality frontend-coverage e2e repo-quality smoke demo-bundle frontend-build schema-diagram schema-diagram-check
 
 help:
 	@echo "up                    Build and start the development stack"
@@ -10,6 +10,7 @@ help:
 	@echo "check                 Run the same checks as CI before push"
 	@echo "backend-quality       Run PHP style, static analysis and dependency audit"
 	@echo "coverage              Enforce backend domain/application coverage >= 90%"
+	@echo "backend-integration   Run Infrastructure repository tests against real MariaDB"
 	@echo "frontend-quality      Run frontend lint and dependency audit"
 	@echo "frontend-coverage     Enforce frontend logic coverage >= 80%"
 	@echo "e2e                   Run critical browser flow against the running stack"
@@ -54,6 +55,9 @@ coverage:
 		exit 1; \
 	fi
 	python3 scripts/check_coverage.py backend/build/coverage/clover.xml --minimum 90
+
+backend-integration:
+	sh scripts/backend-integration.sh
 
 frontend-coverage:
 	npm --prefix frontend ci --no-audit --no-fund

--- a/README.md
+++ b/README.md
@@ -71,6 +71,14 @@ make init
 make smoke
 ```
 
+Интеграционные тесты `RequestRepository`/`DocumentRepository` против отдельной
+тестовой базы `ic_test` в том же сервисе MariaDB (не требует полного запуска
+`make init`, поднимает только `mariadb`):
+
+```bash
+make backend-integration
+```
+
 ## Демо на чистой Windows-машине
 
 Если на целевой машине есть доступ к GitHub и Docker Hub, самый быстрый путь —

--- a/backend/composer.json
+++ b/backend/composer.json
@@ -44,6 +44,7 @@
   "scripts": {
     "lint": "phpcs -n",
     "analyse": "phpstan analyse --no-progress --memory-limit=512M",
-    "test": "phpunit --colors=always"
+    "test": "phpunit --colors=always",
+    "test:integration": "phpunit -c phpunit.integration.xml --colors=always"
   }
 }

--- a/backend/phpunit.integration.xml
+++ b/backend/phpunit.integration.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php" colors="true" cacheDirectory=".phpunit.cache/integration">
+    <testsuites>
+        <testsuite name="integration">
+            <directory>tests/Integration</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/backend/tests/Integration/Document/DocumentRepositoryTest.php
+++ b/backend/tests/Integration/Document/DocumentRepositoryTest.php
@@ -14,13 +14,27 @@ use Tests\Integration\IntegrationTestCase;
 final class DocumentRepositoryTest extends IntegrationTestCase
 {
     private ?string $storageRoot = null;
+    /** @var list<string> */
+    private array $tempFiles = [];
 
     protected function tearDown(): void
     {
-        if ($this->storageRoot !== null && is_dir($this->storageRoot)) {
-            $this->removeDirectory($this->storageRoot);
+        // parent::tearDown() откатывает транзакцию теста — должен выполниться
+        // даже если очистка временных файлов ниже упадёт, иначе следующий
+        // тест унаследует незакоммиченное состояние текущего.
+        try {
+            foreach ($this->tempFiles as $path) {
+                if (is_file($path)) {
+                    // nosemgrep: php.lang.security.unlink-use.unlink-use -- tempnam-created fixture under sys_get_temp_dir()
+                    unlink($path);
+                }
+            }
+            if ($this->storageRoot !== null && is_dir($this->storageRoot)) {
+                $this->removeDirectory($this->storageRoot);
+            }
+        } finally {
+            parent::tearDown();
         }
-        parent::tearDown();
     }
 
     private function storage(): DocumentStorage
@@ -37,6 +51,7 @@ final class DocumentRepositoryTest extends IntegrationTestCase
     {
         $path = tempnam(sys_get_temp_dir(), 'ic-report-');
         file_put_contents($path, $content);
+        $this->tempFiles[] = $path;
         return ['path' => $path, 'size' => strlen($content), 'mime' => 'application/pdf', 'name' => 'report.pdf'];
     }
 

--- a/backend/tests/Integration/Document/DocumentRepositoryTest.php
+++ b/backend/tests/Integration/Document/DocumentRepositoryTest.php
@@ -1,0 +1,179 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Document;
+
+use App\Application\Request\CreateRequestInput;
+use App\Domain\Request\ReportDenied;
+use App\Infrastructure\Document\DocumentRepository;
+use App\Infrastructure\Document\DocumentStorage;
+use App\Infrastructure\Request\RequestRepository;
+use Tests\Integration\IntegrationTestCase;
+
+final class DocumentRepositoryTest extends IntegrationTestCase
+{
+    private ?string $storageRoot = null;
+
+    protected function tearDown(): void
+    {
+        if ($this->storageRoot !== null && is_dir($this->storageRoot)) {
+            $this->removeDirectory($this->storageRoot);
+        }
+        parent::tearDown();
+    }
+
+    private function storage(): DocumentStorage
+    {
+        if ($this->storageRoot === null) {
+            $this->storageRoot = sys_get_temp_dir() . '/ic-integration-' . bin2hex(random_bytes(8));
+            mkdir($this->storageRoot, 0700, true);
+        }
+        return new DocumentStorage($this->storageRoot);
+    }
+
+    /** @return array{path: string, size: int, mime: string, name: string} */
+    private function tempPdf(string $content = '%PDF-1.4 integration test'): array
+    {
+        $path = tempnam(sys_get_temp_dir(), 'ic-report-');
+        file_put_contents($path, $content);
+        return ['path' => $path, 'size' => strlen($content), 'mime' => 'application/pdf', 'name' => 'report.pdf'];
+    }
+
+    /** @return array<string, mixed> */
+    private function createInProgressRequestWithExecutor(int $initiatorId, int $executorId, string $marker): array
+    {
+        $input = new CreateRequestInput();
+        $input->productName = "Изделие {$marker}";
+        $input->manufacturer = 'Завод';
+        $input->supplier = 'Поставщик';
+        $input->sampleQuantity = 1;
+        $input->testMethod = 'Интеграционный тест';
+        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $requestId = (int) $request['id'];
+        $now = gmdate('Y-m-d H:i:s.u');
+
+        $this->db()->createCommand()->update('{{%requests}}', ['status' => 'in_progress'], ['id' => $requestId])->execute();
+        $this->db()->createCommand()->insert('{{%request_assignments}}', [
+            'request_id' => $requestId,
+            'assignment_type' => 'executor',
+            'user_id' => $executorId,
+            'assigned_by' => $initiatorId,
+            'valid_from' => $now,
+        ])->execute();
+
+        return $this->db()->createCommand(
+            'SELECT * FROM {{%requests}} WHERE id = :id',
+            [':id' => $requestId],
+        )->queryOne();
+    }
+
+    public function testReportUploadTransitionsStatusAndNotifiesOnlyActiveExperts(): void
+    {
+        $initiator = $this->createUser('dev.it.doc.initiator1', 'Инициатор');
+        $executor = $this->createUser('dev.it.doc.executor1', 'Исполнитель');
+        $activeExpert = $this->createUser('dev.it.doc.expert1', 'Активный эксперт', 'active.expert@example.invalid');
+        $this->grantRole($activeExpert, 'expert');
+        $inactiveExpert = $this->createUser(
+            'dev.it.doc.expert2',
+            'Неактивный эксперт',
+            'inactive.expert@example.invalid',
+            false,
+        );
+        $this->grantRole($inactiveExpert, 'expert');
+
+        $request = $this->createInProgressRequestWithExecutor($initiator, $executor, 'report-upload');
+        $requestId = (int) $request['id'];
+        $file = $this->tempPdf();
+
+        $repository = new DocumentRepository($this->db(), $this->storage());
+        $result = $repository->uploadReport($requestId, $executor, $file['name'], $file['mime'], $file['size'], $file['path']);
+
+        self::assertSame('opinion_preparation', $result['status']);
+        self::assertSame((int) $request['lock_version'] + 1, $result['lockVersion']);
+
+        $newStatus = $this->scalar('SELECT status FROM {{%requests}} WHERE id = :id', [':id' => $requestId]);
+        self::assertSame('opinion_preparation', $newStatus);
+
+        $activeNotified = $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id "
+            . "AND event_type = 'request.report_uploaded' AND recipient_email = 'active.expert@example.invalid'",
+            [':id' => $requestId],
+        );
+        self::assertSame(1, (int) $activeNotified);
+
+        $inactiveNotified = $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id "
+            . "AND event_type = 'request.report_uploaded' AND recipient_email = 'inactive.expert@example.invalid'",
+            [':id' => $requestId],
+        );
+        self::assertSame(0, (int) $inactiveNotified);
+
+        $auditRuleId = $this->scalar(
+            "SELECT rule_id FROM {{%audit_events}} WHERE event_type = 'request.report_uploaded' "
+            . 'AND entity_id = :id ORDER BY id DESC LIMIT 1',
+            [':id' => $requestId],
+        );
+        self::assertSame('DOC-002', $auditRuleId);
+    }
+
+    public function testUnrelatedEmployeeCannotUploadReport(): void
+    {
+        $initiator = $this->createUser('dev.it.doc.initiator2', 'Инициатор');
+        $executor = $this->createUser('dev.it.doc.executor2', 'Исполнитель');
+        $outsider = $this->createUser('dev.it.doc.outsider1', 'Посторонний сотрудник');
+        $request = $this->createInProgressRequestWithExecutor($initiator, $executor, 'report-denied');
+        $file = $this->tempPdf();
+
+        $repository = new DocumentRepository($this->db(), $this->storage());
+        $this->expectException(ReportDenied::class);
+        $repository->uploadReport((int) $request['id'], $outsider, $file['name'], $file['mime'], $file['size'], $file['path']);
+    }
+
+    public function testSecondReportUploadCreatesNewVersionWithoutRepeatingStatusTransition(): void
+    {
+        $initiator = $this->createUser('dev.it.doc.initiator3', 'Инициатор');
+        $executor = $this->createUser('dev.it.doc.executor3', 'Исполнитель');
+        $request = $this->createInProgressRequestWithExecutor($initiator, $executor, 'report-revision');
+        $requestId = (int) $request['id'];
+
+        $repository = new DocumentRepository($this->db(), $this->storage());
+        $first = $this->tempPdf('%PDF-1.4 revision one');
+        $firstResult = $repository->uploadReport($requestId, $executor, $first['name'], $first['mime'], $first['size'], $first['path']);
+        self::assertSame(1, $firstResult['version']);
+
+        $second = $this->tempPdf('%PDF-1.4 revision two, slightly longer body');
+        $secondResult = $repository->uploadReport($requestId, $executor, $second['name'], $second['mime'], $second['size'], $second['path']);
+        self::assertSame(2, $secondResult['version']);
+        self::assertSame($firstResult['lockVersion'], $secondResult['lockVersion']);
+
+        $versionCount = $this->scalar(
+            'SELECT COUNT(*) FROM {{%request_document_versions}} v '
+            . "JOIN {{%request_documents}} d ON d.id = v.document_id "
+            . "WHERE d.request_id = :id AND d.document_type = 'report'",
+            [':id' => $requestId],
+        );
+        self::assertSame(2, (int) $versionCount);
+    }
+
+    private function removeDirectory(string $path): void
+    {
+        $items = scandir($path);
+        if ($items === false) {
+            return;
+        }
+        foreach ($items as $item) {
+            if ($item === '.' || $item === '..') {
+                continue;
+            }
+            $itemPath = $path . '/' . $item;
+            if (is_dir($itemPath)) {
+                $this->removeDirectory($itemPath);
+            } else {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- temporary test-only storage root
+                unlink($itemPath);
+            }
+        }
+        rmdir($path);
+    }
+}

--- a/backend/tests/Integration/IntegrationTestCase.php
+++ b/backend/tests/Integration/IntegrationTestCase.php
@@ -1,0 +1,98 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration;
+
+use PHPUnit\Framework\TestCase;
+use yii\db\Connection;
+use yii\db\Transaction;
+
+/**
+ * Базовый класс интеграционных тестов Infrastructure-репозиториев.
+ *
+ * Требует реальную MariaDB с уже применёнными миграциями (см.
+ * scripts/backend-integration.sh и phpunit.integration.xml). Каждый тест
+ * выполняется в собственной транзакции, откатываемой в tearDown — методы
+ * репозиториев используют savepoints для своих внутренних транзакций
+ * (Connection::$enableSavepoint включён в Yii по умолчанию), поэтому откат
+ * внешней транзакции безопасно отменяет все изменения теста целиком.
+ */
+abstract class IntegrationTestCase extends TestCase
+{
+    private static ?Connection $connection = null;
+    private ?Transaction $transaction = null;
+
+    protected function db(): Connection
+    {
+        if (self::$connection === null) {
+            $connection = new Connection([
+                'dsn' => sprintf(
+                    'mysql:host=%s;port=%s;dbname=%s',
+                    getenv('DB_HOST') ?: '127.0.0.1',
+                    getenv('DB_PORT') ?: '3306',
+                    getenv('DB_NAME') ?: 'ic_test',
+                ),
+                'username' => getenv('DB_USER') ?: 'ic',
+                'password' => getenv('DB_PASSWORD') ?: '',
+                'charset' => 'utf8mb4',
+            ]);
+            $connection->open();
+            self::$connection = $connection;
+        }
+        return self::$connection;
+    }
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->transaction = $this->db()->beginTransaction();
+    }
+
+    protected function tearDown(): void
+    {
+        $this->transaction?->rollBack();
+        $this->transaction = null;
+        parent::tearDown();
+    }
+
+    protected function createUser(
+        string $adLogin,
+        string $displayName,
+        ?string $email = null,
+        bool $isActive = true,
+    ): int {
+        $now = gmdate('Y-m-d H:i:s.u');
+        $this->db()->createCommand()->insert('{{%users}}', [
+            'ad_login' => $adLogin,
+            'display_name' => $displayName,
+            'email' => $email ?? ($adLogin . '@example.invalid'),
+            'is_active' => $isActive,
+            'created_at' => $now,
+            'updated_at' => $now,
+        ])->execute();
+        return (int) $this->db()->getLastInsertID();
+    }
+
+    protected function grantRole(int $userId, string $roleCode): void
+    {
+        $roleId = $this->db()->createCommand(
+            'SELECT id FROM {{%roles}} WHERE code = :code',
+            [':code' => $roleCode],
+        )->queryScalar();
+        if ($roleId === false) {
+            throw new \RuntimeException("Unknown role code: {$roleCode}");
+        }
+        $this->db()->createCommand()->insert('{{%user_roles}}', [
+            'user_id' => $userId,
+            'role_id' => (int) $roleId,
+            'created_at' => gmdate('Y-m-d H:i:s.u'),
+        ])->execute();
+    }
+
+    /** @param array<string, mixed> $params */
+    protected function scalar(string $sql, array $params = []): mixed
+    {
+        return $this->db()->createCommand($sql, $params)->queryScalar();
+    }
+}

--- a/backend/tests/Integration/Request/RequestRepositoryTest.php
+++ b/backend/tests/Integration/Request/RequestRepositoryTest.php
@@ -1,0 +1,192 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use App\Application\Request\CreateRequestInput;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\RejectDenied;
+use App\Domain\Request\WithdrawDenied;
+use App\Infrastructure\Request\RequestRepository;
+use Tests\Integration\IntegrationTestCase;
+
+final class RequestRepositoryTest extends IntegrationTestCase
+{
+    /** @return array<string, mixed> */
+    private function createRegisteredRequest(int $initiatorId, string $marker): array
+    {
+        $input = new CreateRequestInput();
+        $input->productName = "Тестовое изделие {$marker}";
+        $input->manufacturer = 'Тестовый завод';
+        $input->supplier = 'Тестовый поставщик';
+        $input->sampleQuantity = 1;
+        $input->testMethod = 'Интеграционный тест';
+
+        return (new RequestRepository($this->db()))->create($input, $initiatorId);
+    }
+
+    public function testRejectFailsOnStaleLockVersion(): void
+    {
+        $manager = $this->createUser('dev.it.manager1', 'Тестовый руководитель 1');
+        $this->grantRole($manager, 'ic_manager');
+        $initiator = $this->createUser('dev.it.initiator1', 'Тестовый инициатор 1');
+        $request = $this->createRegisteredRequest($initiator, 'stale-reject');
+
+        $repository = new RequestRepository($this->db());
+        $this->expectException(ConcurrentRequestModification::class);
+        $repository->rejectRequest((int) $request['id'], (int) $request['lock_version'] + 1, $manager);
+    }
+
+    public function testRejectByManagerTransitionsStatusAndWritesAudit(): void
+    {
+        $manager = $this->createUser('dev.it.manager2', 'Тестовый руководитель 2');
+        $this->grantRole($manager, 'ic_manager');
+        $initiator = $this->createUser('dev.it.initiator2', 'Тестовый инициатор 2');
+        $request = $this->createRegisteredRequest($initiator, 'reject-audit');
+
+        $repository = new RequestRepository($this->db());
+        $result = $repository->rejectRequest((int) $request['id'], (int) $request['lock_version'], $manager);
+
+        self::assertSame('rejected', $result['status']);
+        self::assertSame((int) $request['lock_version'] + 1, $result['lockVersion']);
+
+        $auditCount = $this->scalar(
+            "SELECT COUNT(*) FROM {{%audit_events}} WHERE event_type = 'request.rejected' AND entity_id = :id",
+            [':id' => $request['id']],
+        );
+        self::assertSame(1, (int) $auditCount);
+    }
+
+    public function testOnlyManagerCanReject(): void
+    {
+        $employee = $this->createUser('dev.it.employee1', 'Обычный сотрудник');
+        $initiator = $this->createUser('dev.it.initiator3', 'Тестовый инициатор 3');
+        $request = $this->createRegisteredRequest($initiator, 'reject-denied');
+
+        $repository = new RequestRepository($this->db());
+        $this->expectException(RejectDenied::class);
+        $repository->rejectRequest((int) $request['id'], (int) $request['lock_version'], $employee);
+    }
+
+    public function testOnlyInitiatorCanWithdraw(): void
+    {
+        $other = $this->createUser('dev.it.other1', 'Другой сотрудник');
+        $initiator = $this->createUser('dev.it.initiator4', 'Тестовый инициатор 4');
+        $request = $this->createRegisteredRequest($initiator, 'withdraw-denied');
+
+        $repository = new RequestRepository($this->db());
+        $this->expectException(WithdrawDenied::class);
+        $repository->withdrawRequest((int) $request['id'], (int) $request['lock_version'], $other);
+    }
+
+    public function testWithdrawIsBlockedAfterSecurityReview(): void
+    {
+        $initiator = $this->createUser('dev.it.initiator5', 'Тестовый инициатор 5');
+        $expert = $this->createUser('dev.it.expert1', 'Тестовый эксперт');
+        $request = $this->createRegisteredRequest($initiator, 'withdraw-after-sb');
+        $requestId = (int) $request['id'];
+        $now = gmdate('Y-m-d H:i:s.u');
+
+        // Имитируем прохождение контроля СБ напрямую в БД — минимальная
+        // цепочка FK (документ → версия → заключение → security_checks),
+        // без прогона полного HTTP-цикла отчёт/заключение.
+        $this->db()->createCommand()->insert('{{%request_documents}}', [
+            'request_id' => $requestId,
+            'title' => 'Экспертное заключение',
+            'created_by' => $expert,
+            'created_at' => $now,
+        ])->execute();
+        $documentId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%request_document_versions}}', [
+            'document_id' => $documentId,
+            'version' => 1,
+            'storage_key' => str_repeat('a', 64),
+            'original_name' => 'opinion.pdf',
+            'mime_type' => 'application/pdf',
+            'size_bytes' => 1,
+            'sha256' => str_repeat('0', 64),
+            'uploaded_by' => $expert,
+            'created_at' => $now,
+        ])->execute();
+        $versionId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%expert_opinions}}', [
+            'request_id' => $requestId,
+            'revision' => 1,
+            'expert_id' => $expert,
+            'body' => 'Заключение соответствует требованиям.',
+            'document_version_id' => $versionId,
+            'created_at' => $now,
+        ])->execute();
+        $opinionId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%security_checks}}', [
+            'request_id' => $requestId,
+            'expert_opinion_id' => $opinionId,
+            'officer_id' => $expert,
+            'decision' => 'return',
+            'created_at' => $now,
+        ])->execute();
+
+        $repository = new RequestRepository($this->db());
+        $this->expectException(ConcurrentRequestModification::class);
+        $repository->withdrawRequest($requestId, (int) $request['lock_version'], $initiator);
+    }
+
+    public function testCanRejectAndCanWithdrawFlagsInRegistry(): void
+    {
+        $manager = $this->createUser('dev.it.manager3', 'Тестовый руководитель 3');
+        $this->grantRole($manager, 'ic_manager');
+        $initiator = $this->createUser('dev.it.initiator6', 'Тестовый инициатор 6');
+        $request = $this->createRegisteredRequest($initiator, 'registry-flags');
+
+        $repository = new RequestRepository($this->db());
+
+        $managerRow = self::findRow($repository->findLatest($manager, 500), (int) $request['id']);
+        self::assertSame(1, (int) $managerRow['can_reject']);
+        self::assertSame(0, (int) $managerRow['can_withdraw']);
+
+        $initiatorRow = self::findRow($repository->findLatest($initiator, 500), (int) $request['id']);
+        self::assertSame(0, (int) $initiatorRow['can_reject']);
+        self::assertSame(1, (int) $initiatorRow['can_withdraw']);
+    }
+
+    public function testManagerWithTwoRolesIsNotifiedOnlyOnceOnCreate(): void
+    {
+        // WF-008/NTF-003: один и тот же пользователь с ролями ic_manager и
+        // laboratory_manager должен получить ровно одно письмо о создании
+        // заявки, а не по одному на каждую роль (регрессия, найденная Qodo
+        // в PR #58).
+        $dualRoleManager = $this->createUser(
+            'dev.it.dualmanager',
+            'Совмещённый руководитель',
+            'dual.manager@example.invalid',
+        );
+        $this->grantRole($dualRoleManager, 'ic_manager');
+        $this->grantRole($dualRoleManager, 'laboratory_manager');
+        $initiator = $this->createUser('dev.it.initiator7', 'Тестовый инициатор 7');
+
+        $request = $this->createRegisteredRequest($initiator, 'notify-dedup');
+
+        $notifiedCount = $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} "
+            . "WHERE request_id = :id AND event_type = 'request.created' "
+            . "AND recipient_email = 'dual.manager@example.invalid'",
+            [':id' => $request['id']],
+        );
+        self::assertSame(1, (int) $notifiedCount);
+    }
+
+    /**
+     * @param list<array<string, mixed>> $rows
+     * @return array<string, mixed>
+     */
+    private static function findRow(array $rows, int $requestId): array
+    {
+        foreach ($rows as $row) {
+            if ((int) $row['id'] === $requestId) {
+                return $row;
+            }
+        }
+        self::fail("Row for request {$requestId} not found in registry listing.");
+    }
+}

--- a/docker/coverage.Dockerfile
+++ b/docker/coverage.Dockerfile
@@ -5,7 +5,7 @@ ARG XDEBUG_VERSION=3.5.3
 # Build-only packages follow the pinned Alpine base repository as one set.
 # hadolint ignore=DL3018,SC2086
 RUN apk add --no-cache libxml2-dev libzip-dev oniguruma-dev \
-    && docker-php-ext-install dom mbstring zip \
+    && docker-php-ext-install dom mbstring pdo_mysql zip \
     && apk add --no-cache --virtual .coverage-build-deps $PHPIZE_DEPS linux-headers \
     && pecl install "xdebug-${XDEBUG_VERSION}" \
     && docker-php-ext-enable xdebug \

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -36,12 +36,19 @@
 
 1. статический анализ и форматирование;
 2. все domain unit tests;
-3. integration tests на чистой MariaDB;
+3. integration tests на чистой MariaDB (`make backend-integration`,
+   CI job `backend-integration`) — `RequestRepository`/`DocumentRepository`
+   против применённых с нуля миграций в отдельной базе `ic_test`, каждый
+   тест в своей транзакции с откатом после теста;
 4. миграция БД с нуля;
 5. frontend unit tests и production build;
 6. критический smoke-набор Playwright;
 7. проверка, что production bundle не содержит внешних HTTP-зависимостей;
 8. отчёт покрытия и JUnit-отчёты в GitLab.
+
+Integration-контур сознательно не входит в локальный `make check`/pre-push
+hook (как и `make smoke`/`make e2e`) — требует поднятия реальной MariaDB и
+замедлил бы каждый push; он обязателен только как отдельный CI job.
 
 ## Критические E2E-сценарии
 

--- a/scripts/backend-integration.sh
+++ b/scripts/backend-integration.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env sh
+set -eu
+
+# Прогоняет интеграционные тесты Infrastructure-репозиториев
+# (RequestRepository, DocumentRepository) против реальной MariaDB —
+# отдельная база `ic_test` в том же сервисе, что и dev/demo-контур, не
+# пересекается с его данными и накатывается идемпотентно при каждом запуске.
+
+project_root=$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)
+cd "$project_root"
+
+test_db_name=${TEST_DB_NAME:-ic_test}
+network_name=${INTEGRATION_NETWORK:-shlz-test-registry_default}
+image_tag=shlz-test-registry-coverage
+
+if [ ! -f .env ]; then
+  cp .env.example .env
+fi
+
+docker compose up -d mariadb
+
+attempts=0
+until docker compose exec -T mariadb healthcheck.sh --connect --innodb_initialized >/dev/null 2>&1; do
+  attempts=$((attempts + 1))
+  if [ "$attempts" -ge 30 ]; then
+    echo "MariaDB did not become healthy" >&2
+    exit 1
+  fi
+  sleep 2
+done
+
+db_user=$(grep -m1 '^DB_USER=' .env | cut -d= -f2-)
+db_password=$(grep -m1 '^DB_PASSWORD=' .env | cut -d= -f2-)
+
+# Тестовая база создаётся под тем же пользователем, что и dev/demo-база
+# (см. MARIADB_USER/MARIADB_PASSWORD в compose.yaml) — отдельный
+# пользователь не нужен, достаточно выдать ему права ещё на одну схему.
+docker compose exec -T mariadb sh -lc \
+  'mariadb --user=root --password="$MARIADB_ROOT_PASSWORD" --execute "$1"' \
+  sh "CREATE DATABASE IF NOT EXISTS \`$test_db_name\` CHARACTER SET utf8mb4 COLLATE utf8mb4_unicode_ci; GRANT ALL PRIVILEGES ON \`$test_db_name\`.* TO '$db_user'@'%';"
+
+docker build --file docker/coverage.Dockerfile --tag "$image_tag" .
+
+docker run --rm \
+  --network "$network_name" \
+  -e DB_HOST=mariadb \
+  -e DB_PORT=3306 \
+  -e DB_NAME="$test_db_name" \
+  -e DB_USER="$db_user" \
+  -e DB_PASSWORD="$db_password" \
+  -e APP_PUBLIC_URL=http://localhost:8080 \
+  "$image_tag" \
+  sh -c 'php yii migrate/up && vendor/bin/phpunit -c phpunit.integration.xml --colors=always'


### PR DESCRIPTION
## Что сделано

Closes #60

Поднята инфраструктура интеграционных тестов для `RequestRepository` и
`DocumentRepository` против реальной MariaDB. До этого PR в проекте были
только unit-тесты для `Domain/*Policy` (чистые функции с уже вычисленными
булевыми флагами) — вся бизнес-логика, завязанная на SQL (переходы статусов,
optimistic locking через `lock_version`, условия видимости capability-флагов,
запись `audit_events`/`request_transitions`, дедупликация уведомлений в
outbox), тестами не покрывалась вообще. Оба бага, найденных Qodo в PR #58,
были невидимы именно по этой причине.

## Как это устроено

- `scripts/backend-integration.sh` (он же `make backend-integration`):
  поднимает `mariadb` (без остального стека), создаёт отдельную тестовую базу
  `ic_test` под тем же пользователем, что и dev/demo-база (не пересекается с
  её данными), прогоняет миграции с нуля и PHPUnit — внутри уже
  существующего `coverage.Dockerfile`-образа (добавил туда `pdo_mysql`,
  раньше не был нужен).
- `IntegrationTestCase`: каждый тест выполняется в своей транзакции,
  откатываемой в `tearDown`. Внутренние транзакции самих репозиториев
  становятся savepoint'ами (`enableSavepoint` включён в Yii по умолчанию),
  поэтому откат внешней транзакции безопасно отменяет все изменения теста
  без TRUNCATE между тестами.
- `phpunit.integration.xml` — отдельный конфиг с отдельным testsuite
  (`tests/Integration`), полностью изолированный от `phpunit.xml`
  (`composer test`/`make coverage`/90%-порог Domain/Application не видят
  и не запускают эти тесты, БД для обычного unit-прогона не нужна).

## Что покрыто (ключевые сценарии из issue)

- `testRejectFailsOnStaleLockVersion` / гонка через `lock_version`;
- `testRejectByManagerTransitionsStatusAndWritesAudit` — переход статуса +
  запись `audit_events` одной транзакцией;
- `testOnlyManagerCanReject` / `testOnlyInitiatorCanWithdraw` —
  авторизационные ветки `RejectPolicy`/`WithdrawPolicy` через реальный SQL;
- `testWithdrawIsBlockedAfterSecurityReview` — WF-007 (отзыв невозможен
  после решения СБ, даже если заявка формально в отзываемом статусе);
- `testCanRejectAndCanWithdrawFlagsInRegistry` — видимость `can_reject`/
  `can_withdraw` в `findLatest()` для разных ролей;
- `testManagerWithTwoRolesIsNotifiedOnlyOnceOnCreate` — регрессия ровно
  того бага из PR #58 (дедупликация письма при совпадении получателя у
  пользователя с двумя ролями);
- `testReportUploadTransitionsStatusAndNotifiesOnlyActiveExperts` /
  `testUnrelatedEmployeeCannotUploadReport` /
  `testSecondReportUploadCreatesNewVersionWithoutRepeatingStatusTransition` —
  `DocumentRepository::uploadReport()`: переход статуса, рассылка только
  активным экспертам, отказ постороннему сотруднику, версионирование без
  повторного перехода.

## Почему не в `make check`/pre-push hook

По аналогии с `make smoke`/`make e2e` — требует реальной MariaDB, замедлил
бы каждый push. Обязателен только как отдельный CI job `backend-integration`,
что и описывает `docs/test-strategy.md` («Application integration | PHPUnit +
test MariaDB» в контурах, п. 3 обязательных проверок MR).

## Test plan

- [x] `make backend-integration` — 10 тестов, зелёные, дважды подряд
      (идемпотентность миграций, отсутствие утечки состояния между запусками)
- [x] `composer lint` / `composer analyse` (включая новые файлы в `tests/`)
- [x] `composer test` — подтверждено, что интеграционные тесты НЕ попадают в
      обычный unit-прогон и не требуют БД
- [x] `make coverage` — порог 90% не затронут (95.16%, как и до PR)
- [x] `make check` (pre-push gate) — зелёный
- [x] `hadolint docker/coverage.Dockerfile`, `shellcheck`/`shfmt` нового
      скрипта, `actionlint .github/workflows/ci.yml`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdoygMzQ45xsa4W6jBA4rX