### PR TITLE
Интеграционные тесты записи импорта Bitrix24 (частично issue #15)

### DIFF
--- a/backend/tests/Integration/Import/DatabaseLegacyRequestWriterTest.php
+++ b/backend/tests/Integration/Import/DatabaseLegacyRequestWriterTest.php
@@ -1,0 +1,129 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Import;
+
+use App\Application\Import\LegacyImportOutcome;
+use App\Application\Import\LegacyRequestData;
+use App\Domain\Request\RequestStatus;
+use App\Infrastructure\Import\DatabaseLegacyRequestWriter;
+use DateTimeImmutable;
+use Tests\Integration\IntegrationTestCase;
+
+final class DatabaseLegacyRequestWriterTest extends IntegrationTestCase
+{
+    private function request(
+        string $legacyId,
+        string $creatorLegacyId = '1595',
+        string $department = 'Лаборатория',
+    ): LegacyRequestData {
+        return new LegacyRequestData(
+            $legacyId,
+            'Тестовое изделие',
+            'Тестовый завод',
+            'Тестовый поставщик',
+            2,
+            'Метод испытаний',
+            RequestStatus::Completed,
+            new DateTimeImmutable('2024-01-01T12:00:00+00:00'),
+            $creatorLegacyId,
+            'Иванов Иван',
+            $department,
+            1,
+            0,
+        );
+    }
+
+    public function testFirstWriteCreatesRequestWithAuditAndTransition(): void
+    {
+        $writer = new DatabaseLegacyRequestWriter($this->db());
+        $outcome = $writer->write($this->request('bitrix24:114:501'));
+
+        self::assertSame(LegacyImportOutcome::Created, $outcome);
+
+        $requestId = $this->scalar(
+            'SELECT id FROM {{%requests}} WHERE legacy_id = :legacy_id',
+            [':legacy_id' => 'bitrix24:114:501'],
+        );
+        self::assertNotFalse($requestId);
+
+        $status = $this->scalar('SELECT status FROM {{%requests}} WHERE id = :id', [':id' => $requestId]);
+        self::assertSame('completed', $status);
+
+        $transitionCount = $this->scalar(
+            "SELECT COUNT(*) FROM {{%request_transitions}} WHERE request_id = :id "
+            . "AND action = 'import' AND rule_id = 'IMP-002' AND from_status IS NULL",
+            [':id' => $requestId],
+        );
+        self::assertSame(1, (int) $transitionCount);
+
+        $auditCount = $this->scalar(
+            "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id "
+            . "AND event_type = 'request.imported' AND rule_id = 'IMP-001'",
+            [':id' => $requestId],
+        );
+        self::assertSame(1, (int) $auditCount);
+    }
+
+    public function testRepeatedWriteWithSameLegacyIdIsSkipped(): void
+    {
+        // IMP-001: повторный импорт одной записи не создаёт дубликат заявки.
+        $writer = new DatabaseLegacyRequestWriter($this->db());
+        $legacyId = 'bitrix24:114:502';
+
+        self::assertSame(LegacyImportOutcome::Created, $writer->write($this->request($legacyId)));
+        self::assertSame(LegacyImportOutcome::Skipped, $writer->write($this->request($legacyId)));
+
+        $count = $this->scalar(
+            'SELECT COUNT(*) FROM {{%requests}} WHERE legacy_id = :legacy_id',
+            [':legacy_id' => $legacyId],
+        );
+        self::assertSame(1, (int) $count);
+    }
+
+    public function testImportedInitiatorIsCreatedAsInactivePlaceholder(): void
+    {
+        $writer = new DatabaseLegacyRequestWriter($this->db());
+        $writer->write($this->request('bitrix24:114:503', '77001'));
+
+        $user = $this->db()->createCommand(
+            "SELECT is_active, display_name, department FROM {{%users}} WHERE ad_login = 'legacy.bitrix24.77001'",
+        )->queryOne();
+
+        self::assertNotFalse($user);
+        self::assertSame(0, (int) $user['is_active']);
+        self::assertSame('Иванов Иван', $user['display_name']);
+        self::assertSame('Лаборатория', $user['department']);
+    }
+
+    public function testSameLegacyCreatorIsReusedAcrossRequests(): void
+    {
+        $writer = new DatabaseLegacyRequestWriter($this->db());
+        $writer->write($this->request('bitrix24:114:504', '77002'));
+        $writer->write($this->request('bitrix24:114:505', '77002'));
+
+        $userCount = $this->scalar(
+            "SELECT COUNT(*) FROM {{%users}} WHERE ad_login = 'legacy.bitrix24.77002'",
+        );
+        self::assertSame(1, (int) $userCount);
+
+        $requestCount = $this->scalar(
+            'SELECT COUNT(*) FROM {{%requests}} r JOIN {{%users}} u ON u.id = r.initiator_id '
+            . "WHERE u.ad_login = 'legacy.bitrix24.77002'",
+        );
+        self::assertSame(2, (int) $requestCount);
+    }
+
+    public function testMissingDepartmentIsStoredAsNull(): void
+    {
+        // IMP-004: избыточные/отсутствующие персональные данные не переносятся как есть.
+        $writer = new DatabaseLegacyRequestWriter($this->db());
+        $writer->write($this->request('bitrix24:114:506', '77003', ''));
+
+        $department = $this->db()->createCommand(
+            "SELECT department FROM {{%users}} WHERE ad_login = 'legacy.bitrix24.77003'",
+        )->queryScalar();
+        self::assertNull($department);
+    }
+}


### PR DESCRIPTION
## Контекст

Изучил текущее состояние issue #15 перед тем, как браться за неё целиком —
оказалось, что бóльшая часть плана уже реализована и хорошо
задокументирована: read-only клиент (`BitrixListClient`/`NativeBitrixTransport`
с retry/backoff, allowlist методов, обязательный HTTPS), безопасная команда
`bitrix/inspect` (не выводит содержимое заявок), маппер (`LegacyRequestMapper`
— решил проблему из issue с недоступностью `PROPERTY_646`/`PROPERTY_648` через
`SELECT`, читая структурированные данные из `DETAIL_TEXT` вместо кастомных
свойств), `bitrix/import --apply=0/1` с идемпотентной записью по `legacy_id`,
и `docs/integrations/bitrix24.md`.

Не закрываю issue #15 этим PR — она не в состоянии "готово".

## Что сделано в этом PR

Из всего пайплайна импорта только `DatabaseLegacyRequestWriter` (реальная
запись в БД: дедупликация по `legacy_id`, заведение неактивного технического
профиля инициатора, запись `audit_events`/`request_transitions`) оставался без
тестов — единственный компонент, до которого не добрался ни один из уже
существующих `LegacyRequestMapperTest`/`LegacyRequestImporterTest`/
`NativeBitrixTransportTest`/`BitrixListClientTest` (те тестируют чистую логику
или используют фейковый `LegacyRequestWriter`).

Теперь покрыт через интеграционный контур из PR #69 (реальная MariaDB,
транзакция с откатом на тест, синтетические данные):

- первая запись создаёт заявку + `IMP-001` в аудите + `IMP-002` в переходах;
- повторная запись с тем же `legacy_id` пропускается, дубликат не создаётся;
- инициатор заводится неактивным техническим профилем с ФИО/подразделением;
- один и тот же `creatorLegacyId` переиспользует один и тот же профиль между
  несколькими заявками (не плодит дубли пользователей);
- отсутствующее подразделение сохраняется как `NULL`, а не пустая строка.

## Что осталось нерешённым в issue #15 (не в этом PR)

Перенос вложений (`supportingDocFiles`/`reportFiles`) — сейчас маппер только
считает количество файлов, но не переносит содержимое. Формат их реального
получения из Bitrix24 (URL, `disk.file.get` или что-то ещё) требует
исследования против настоящего API или образцов реальных ответов, которых у
меня нет и которые я не буду угадывать для интеграции с реальными
корпоративными данными — заведомо неверная догадка тут хуже отсутствия кода.
Если есть свежие образцы ответов API по этим полям — дайте знать, доделаю.

## Test plan

- [x] `make backend-integration` — 15 тестов (10 существующих + 5 новых),
      зелёные
- [x] `composer lint` / `composer analyse` (новый файл в `tests/`)
- [x] `composer test` — подтверждено, что новый тест не попадает в обычный
      unit-прогон
- [x] `make check` (pre-push gate) — зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MdoygMzQ45xsa4W6jBA4rX