### PR TITLE
Уточнить заголовок загрузки отчёта при замене уже загруженного

### DIFF
--- a/frontend/src/App.vue
+++ b/frontend/src/App.vue
@@ -1192,8 +1192,8 @@ onMounted(bootstrapAuth)
                 <p v-if="actionError" class="action-error">{{ actionError }}</p>
 
                 <div v-if="selected.canUploadReport" class="hero-block">
-                  <h4>Загрузите отчёт испытаний</h4>
-                  <p class="hero-sub">Заявка перейдёт на подготовку экспертного заключения сразу после загрузки</p>
+                  <h4>{{ selected.canDeleteReport ? 'Загрузить новую версию отчёта' : 'Загрузите отчёт испытаний' }}</h4>
+                  <p class="hero-sub">{{ selected.canDeleteReport ? 'Текущий отчёт не удаляется — новая версия добавляется поверх' : 'Заявка перейдёт на подготовку экспертного заключения сразу после загрузки' }}</p>
                   <div class="hero-actions"><label class="primary upload-button big">{{ reportLoading ? 'Загрузка отчёта…' : 'Загрузить отчёт испытаний' }}<input type="file" :disabled="reportLoading" accept=".pdf,application/pdf" @change="uploadReport" /></label></div>
                   <p v-if="reportError" class="action-error">{{ reportError }}</p>
                   <a class="help-link" href="/help/report.html" target="_blank">Инструкция по загрузке отчёта испытаний</a>


### PR DESCRIPTION
## Проблема

Найдено при подготовке макета карточки заявки: `canUploadReport`
остаётся `true` не только для первой загрузки, но и пока статус
«Подготовка заключения» — то есть для замены уже загруженного отчёта
новой версией (DOC-008). Одновременно доступно `canDeleteReport` (если
отчёт уже есть) — пользователь видел заголовок «Загрузите отчёт
испытаний» рядом с кнопкой «Удалить отчёт», что читалось как
противоречие: то ли отчёта ещё нет, то ли он уже есть.

## Что сделано

Заголовок и подзаголовок блока теперь зависят от `canDeleteReport`
(устойчивый признак «активный отчёт уже существует», уже используется
как условие самой кнопки удаления) — «Загрузить новую версию отчёта»
вместо «Загрузите отчёт испытаний» для случая замены. Сама кнопка
загрузки и `docs/user/report.md`/`help/report.html` не менялись — они
цитируют текст кнопки, а не заголовка.

## Проверка

- Визуально проверено Playwright-скриншотом: заявка с уже загруженным
  отчётом (статус «Подготовка заключения») показывает «Загрузить новую
  версию отчёта» и поясняющий подзаголовок.
- `npx playwright test` — 3/3 зелёные.
- `npm run lint` / `vitest run` — 67/67.
- `make check` — зелёный (прогнан pre-push hook).

🤖 Generated with [Claude Code](https://claude.com/claude-code)