### PR TITLE
Исправить миграцию связей отчётов после ревью

### DIFF
--- a/backend/migrations/m260730_000002_link_report_transition_to_document_version.php
+++ b/backend/migrations/m260730_000002_link_report_transition_to_document_version.php
@@ -29,11 +29,12 @@ final class m260730_000002_link_report_transition_to_document_version extends Mi
         $this->createIndex(
             'idx_document_version_created_at',
             '{{%request_document_versions}}',
-            ['document_id', 'created_at'],
+            ['document_id', 'created_at', 'id'],
         );
         // Existing upload events predate the explicit relation. Associate
-        // each one with the closest report version of the same request;
-        // future events are linked directly at insert time.
+        // each one with the latest report version at or before the event,
+        // falling back to the earliest version after it. Future events are
+        // linked directly at insert time.
         $this->execute(
             "UPDATE {{%request_transitions}} transition_event SET document_version_id = COALESCE(("
             . 'SELECT version.id FROM {{%request_document_versions}} version '

--- a/backend/migrations/m260730_000002_link_report_transition_to_document_version.php
+++ b/backend/migrations/m260730_000002_link_report_transition_to_document_version.php
@@ -13,6 +13,11 @@ final class m260730_000002_link_report_transition_to_document_version extends Mi
             'document_version_id',
             $this->bigInteger()->unsigned()->null()->after('reason'),
         );
+        $this->createIndex(
+            'idx_transition_document_version',
+            '{{%request_transitions}}',
+            'document_version_id',
+        );
         $this->addForeignKey(
             'fk_transition_document_version',
             '{{%request_transitions}}',
@@ -22,19 +27,25 @@ final class m260730_000002_link_report_transition_to_document_version extends Mi
             'SET NULL',
         );
         $this->createIndex(
-            'idx_transition_document_version',
-            '{{%request_transitions}}',
-            'document_version_id',
+            'idx_document_version_created_at',
+            '{{%request_document_versions}}',
+            ['document_id', 'created_at'],
         );
         // Existing upload events predate the explicit relation. Associate
         // each one with the closest report version of the same request;
         // future events are linked directly at insert time.
         $this->execute(
-            "UPDATE {{%request_transitions}} transition_event SET document_version_id = ("
+            "UPDATE {{%request_transitions}} transition_event SET document_version_id = COALESCE(("
             . 'SELECT version.id FROM {{%request_document_versions}} version '
             . 'JOIN {{%request_documents}} document ON document.id = version.document_id '
             . "WHERE document.request_id = transition_event.request_id AND document.document_type = 'report' "
-            . 'ORDER BY ABS(TIMESTAMPDIFF(MICROSECOND, version.created_at, transition_event.created_at)), version.id LIMIT 1) '
+            . 'AND version.created_at <= transition_event.created_at '
+            . 'ORDER BY version.created_at DESC, version.id DESC LIMIT 1), ('
+            . 'SELECT version.id FROM {{%request_document_versions}} version '
+            . 'JOIN {{%request_documents}} document ON document.id = version.document_id '
+            . "WHERE document.request_id = transition_event.request_id AND document.document_type = 'report' "
+            . 'AND version.created_at > transition_event.created_at '
+            . 'ORDER BY version.created_at, version.id LIMIT 1)) '
             . "WHERE transition_event.action = 'upload_report' AND transition_event.document_version_id IS NULL",
         );
     }
@@ -43,6 +54,7 @@ final class m260730_000002_link_report_transition_to_document_version extends Mi
     {
         $this->dropForeignKey('fk_transition_document_version', '{{%request_transitions}}');
         $this->dropIndex('idx_transition_document_version', '{{%request_transitions}}');
+        $this->dropIndex('idx_document_version_created_at', '{{%request_document_versions}}');
         $this->dropColumn('{{%request_transitions}}', 'document_version_id');
     }
 }


### PR DESCRIPTION
Исправляет два замечания финального Qodo review к #130:

- создаёт индекс переходов до внешнего ключа, чтобы InnoDB не создавал дубликат;
- добавляет составной индекс версий и заменяет неиндексируемую сортировку по `ABS(TIMESTAMPDIFF(...))` на поиск последней версии до события с fallback на первую после него.

Проверено на чистой базе: все 14 миграций и backend integration проходят.