### PR TITLE
Экспертное заключение: оформление PDF в стиле портала

### DIFF
--- a/backend/src/Infrastructure/Document/OpinionPdfRenderer.php
+++ b/backend/src/Infrastructure/Document/OpinionPdfRenderer.php
@@ -22,7 +22,16 @@ final class OpinionPdfRenderer
     }
 
     /**
-     * @param array{number: int, productName: string, manufacturer: string, supplier: string, expertName: string, expertPosition: string, body: string, date: string} $data
+     * @param array{
+     *     number: int,
+     *     productName: string,
+     *     manufacturer: string,
+     *     supplier: string,
+     *     expertName: string,
+     *     expertPosition: string,
+     *     body: string,
+     *     date: string
+     * } $data
      * @internal Public to keep the document template directly testable without parsing a PDF binary.
      */
     public function renderHtml(array $data): string
@@ -34,46 +43,40 @@ final class OpinionPdfRenderer
         );
 
         return '<!doctype html><html lang="ru"><head><meta charset="utf-8"><style>'
-            . '@page{margin:22mm 19mm 20mm}'
-            . 'body{margin:0;color:#172337;font-family:"DejaVu Sans",sans-serif;font-size:11px;line-height:1.5}'
-            . '.document-header{padding-bottom:18px;border-bottom:2px solid #253d98}'
-            . '.brand{width:100%;border-collapse:collapse}.brand-mark{width:42px;vertical-align:middle}'
-            . '.brand-copy{padding-left:12px;vertical-align:middle}.brand-copy strong{display:block;color:#253d98;font-size:12px}'
-            . '.brand-copy span{display:block;margin-top:2px;color:#6e7a8b;font-size:9px;letter-spacing:.08em;text-transform:uppercase}'
-            . 'h1{margin:22px 0 5px;color:#253d98;font-size:20px;line-height:1.3;font-weight:600}'
-            . '.request-number{margin:0;color:#6e7a8b;font-size:10px;letter-spacing:.05em;text-transform:uppercase}'
-            . '.section{margin-top:24px}.section-title{margin:0 0 11px;color:#253d98;font-size:12px;font-weight:600}'
-            . '.facts{width:100%;border-collapse:collapse;border-top:1px solid #dde3ec;border-bottom:1px solid #dde3ec}'
-            . '.facts td{width:33.333%;padding:11px 12px 12px 0;vertical-align:top}'
-            . '.facts td+td{padding-left:12px;border-left:1px solid #dde3ec}'
-            . '.label{display:block;margin-bottom:4px;color:#8a96a7;font-size:8px;letter-spacing:.08em;text-transform:uppercase}'
-            . '.value{display:block;color:#172337;font-size:11px;font-weight:600;line-height:1.4}'
-            . '.opinion{min-height:180px;margin:0;padding:15px 0 19px;border-top:1px solid #dde3ec;border-bottom:1px solid #dde3ec;white-space:pre-wrap;font-size:11.5px;line-height:1.65}'
-            . '.signoff{width:100%;margin-top:25px;border-collapse:collapse}.signoff td{vertical-align:bottom}'
-            . '.expert{padding-right:20px}.date{width:125px;text-align:right}'
-            . '.signoff .value{font-weight:500}.position{display:block;margin-top:2px;color:#6e7a8b;font-size:9.5px}'
-            . '</style></head><body>'
-            . '<header class="document-header"><table class="brand"><tr><td class="brand-mark">'
-            . '<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">'
-            . '<rect x="2" y="2" width="36" height="36" rx="10" fill="#253d98"/>'
-            . '<path d="M12 25a8 8 0 1 1 16 0" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>'
-            . '<path d="M12 25h2M26 25h2M20 15v2" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>'
-            . '<path d="M20 25l5-6.5" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>'
-            . '<circle cx="20" cy="25" r="1.6" fill="#fff"/></svg></td>'
-            . '<td class="brand-copy"><strong>Испытательный центр</strong><span>АО «ЩЛЗ» · Портал заявок</span></td>'
-            . '</tr></table><h1>Экспертное заключение</h1>'
+            . '@page{margin:20mm}'
+            . 'body{margin:0;color:#243047;font-family:"DejaVu Sans",sans-serif;font-size:10.5px;line-height:1.55}'
+            . '.accent-rail{position:fixed;top:-20mm;bottom:-20mm;left:-20mm;width:12mm;background:#253d98}'
+            . '.document{margin-left:7mm}'
+            . '.kicker{color:#253d98;font-size:9px;letter-spacing:.12em;text-transform:uppercase}'
+            . 'h1{margin:10px 0 4px;color:#243047;font-size:24px;line-height:1.25;font-weight:600}'
+            . '.request-number{margin:0 0 28px;color:#768196;font-size:13px}'
+            . '.facts{padding:15px 17px;border-radius:8px;background:#f0f3f8}'
+            . '.fact{margin:0 0 9px}.fact:last-child{margin-bottom:0}'
+            . '.label{display:inline-block;width:120px;color:#7a8596;font-size:8px;letter-spacing:.04em;'
+            . 'text-transform:uppercase}'
+            . '.value{color:#243047}.primary-value{font-weight:600}'
+            . '.section-title{margin:27px 0 10px;color:#253d98;font-size:12px;font-weight:600}'
+            . '.opinion{min-height:195px;margin:0;white-space:pre-wrap;font-size:12px;line-height:1.8}'
+            . '.signoff{width:100%;border-collapse:collapse;border-top:2px solid #253d98}'
+            . '.signoff td{padding-top:13px;vertical-align:top}'
+            . '.expert-name{font-weight:600}.position{display:block;color:#7a8596;font-size:9px}'
+            . '.date{width:145px;text-align:right}'
+            . '</style></head><body><div class="accent-rail"></div><main class="document">'
+            . '<header><div class="kicker">АО «ЩЛЗ» · Испытательный центр</div>'
+            . '<h1>Экспертное заключение</h1>'
             . '<p class="request-number">Заявка № ' . $data['number'] . '</p></header>'
-            . '<section class="section"><h2 class="section-title">Объект испытаний</h2><table class="facts"><tr>'
-            . '<td><span class="label">Наименование</span><span class="value">' . $escape($data['productName']) . '</span></td>'
-            . '<td><span class="label">Производитель</span><span class="value">' . $escape($data['manufacturer']) . '</span></td>'
-            . '<td><span class="label">Поставщик</span><span class="value">' . $escape($data['supplier']) . '</span></td>'
-            . '</tr></table></section>'
-            . '<section class="section"><h2 class="section-title">Заключение</h2>'
+            . '<section class="facts">'
+            . '<div class="fact"><span class="label">Изделие</span><span class="value primary-value">'
+            . $escape($data['productName']) . '</span></div>'
+            . '<div class="fact"><span class="label">Производитель</span><span class="value">'
+            . $escape($data['manufacturer']) . '</span></div>'
+            . '<div class="fact"><span class="label">Поставщик</span><span class="value">'
+            . $escape($data['supplier']) . '</span></div>'
+            . '</section><section><h2 class="section-title">Заключение</h2>'
             . '<p class="opinion">' . $escape($data['body']) . '</p></section>'
-            . '<table class="signoff"><tr><td class="expert"><span class="label">Эксперт</span>'
-            . '<span class="value">' . $escape($data['expertName']) . '</span>'
+            . '<table class="signoff"><tr><td><span class="expert-name">' . $escape($data['expertName']) . '</span>'
             . '<span class="position">' . $escape($data['expertPosition']) . '</span></td>'
-            . '<td class="date"><span class="label">Дата</span><span class="value">' . $escape($data['date']) . '</span></td>'
-            . '</tr></table></body></html>';
+            . '<td class="date">' . $escape($data['date']) . '</td>'
+            . '</tr></table></main></body></html>';
     }
 }

--- a/backend/src/Infrastructure/Document/OpinionPdfRenderer.php
+++ b/backend/src/Infrastructure/Document/OpinionPdfRenderer.php
@@ -12,20 +12,68 @@ final class OpinionPdfRenderer
     /** @param array{number: int, productName: string, manufacturer: string, supplier: string, expertName: string, expertPosition: string, body: string, date: string} $data */
     public function render(array $data): string
     {
-        $escape = static fn (string $value): string => htmlspecialchars($value, ENT_QUOTES | ENT_SUBSTITUTE, 'UTF-8');
         $options = new Options();
         $options->set('defaultFont', 'DejaVu Sans');
         $pdf = new Dompdf($options);
-        $pdf->loadHtml('<!doctype html><html lang="ru"><meta charset="utf-8"><style>body{font-family:"DejaVu Sans";font-size:12px}h1{text-align:center;font-size:18px}dt{font-weight:bold;margin-top:8px}p{white-space:pre-wrap;line-height:1.5}</style><body>'
-            . '<h1>Экспертное заключение по заявке № ' . $data['number'] . '</h1>'
-            . '<dl><dt>Объект испытаний</dt><dd>' . $escape($data['productName']) . '</dd>'
-            . '<dt>Производитель</dt><dd>' . $escape($data['manufacturer']) . '</dd>'
-            . '<dt>Поставщик</dt><dd>' . $escape($data['supplier']) . '</dd></dl>'
-            . '<h2>Заключение</h2><p>' . $escape($data['body']) . '</p>'
-            . '<p>Эксперт: ' . $escape($data['expertName']) . ', ' . $escape($data['expertPosition']) . '<br>Дата: ' . $escape($data['date']) . '</p>'
-            . '</body></html>', 'UTF-8');
+        $pdf->loadHtml($this->renderHtml($data), 'UTF-8');
         $pdf->setPaper('A4');
         $pdf->render();
         return $pdf->output();
+    }
+
+    /**
+     * @param array{number: int, productName: string, manufacturer: string, supplier: string, expertName: string, expertPosition: string, body: string, date: string} $data
+     * @internal Public to keep the document template directly testable without parsing a PDF binary.
+     */
+    public function renderHtml(array $data): string
+    {
+        $escape = static fn (string $value): string => htmlspecialchars(
+            $value,
+            ENT_QUOTES | ENT_SUBSTITUTE,
+            'UTF-8',
+        );
+
+        return '<!doctype html><html lang="ru"><head><meta charset="utf-8"><style>'
+            . '@page{margin:22mm 19mm 20mm}'
+            . 'body{margin:0;color:#172337;font-family:"DejaVu Sans",sans-serif;font-size:11px;line-height:1.5}'
+            . '.document-header{padding-bottom:18px;border-bottom:2px solid #253d98}'
+            . '.brand{width:100%;border-collapse:collapse}.brand-mark{width:42px;vertical-align:middle}'
+            . '.brand-copy{padding-left:12px;vertical-align:middle}.brand-copy strong{display:block;color:#253d98;font-size:12px}'
+            . '.brand-copy span{display:block;margin-top:2px;color:#6e7a8b;font-size:9px;letter-spacing:.08em;text-transform:uppercase}'
+            . 'h1{margin:22px 0 5px;color:#253d98;font-size:20px;line-height:1.3;font-weight:600}'
+            . '.request-number{margin:0;color:#6e7a8b;font-size:10px;letter-spacing:.05em;text-transform:uppercase}'
+            . '.section{margin-top:24px}.section-title{margin:0 0 11px;color:#253d98;font-size:12px;font-weight:600}'
+            . '.facts{width:100%;border-collapse:collapse;border-top:1px solid #dde3ec;border-bottom:1px solid #dde3ec}'
+            . '.facts td{width:33.333%;padding:11px 12px 12px 0;vertical-align:top}'
+            . '.facts td+td{padding-left:12px;border-left:1px solid #dde3ec}'
+            . '.label{display:block;margin-bottom:4px;color:#8a96a7;font-size:8px;letter-spacing:.08em;text-transform:uppercase}'
+            . '.value{display:block;color:#172337;font-size:11px;font-weight:600;line-height:1.4}'
+            . '.opinion{min-height:180px;margin:0;padding:15px 0 19px;border-top:1px solid #dde3ec;border-bottom:1px solid #dde3ec;white-space:pre-wrap;font-size:11.5px;line-height:1.65}'
+            . '.signoff{width:100%;margin-top:25px;border-collapse:collapse}.signoff td{vertical-align:bottom}'
+            . '.expert{padding-right:20px}.date{width:125px;text-align:right}'
+            . '.signoff .value{font-weight:500}.position{display:block;margin-top:2px;color:#6e7a8b;font-size:9.5px}'
+            . '</style></head><body>'
+            . '<header class="document-header"><table class="brand"><tr><td class="brand-mark">'
+            . '<svg width="40" height="40" viewBox="0 0 40 40" xmlns="http://www.w3.org/2000/svg">'
+            . '<rect x="2" y="2" width="36" height="36" rx="10" fill="#253d98"/>'
+            . '<path d="M12 25a8 8 0 1 1 16 0" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>'
+            . '<path d="M12 25h2M26 25h2M20 15v2" fill="none" stroke="#fff" stroke-width="1.6" stroke-linecap="round"/>'
+            . '<path d="M20 25l5-6.5" fill="none" stroke="#fff" stroke-width="2" stroke-linecap="round"/>'
+            . '<circle cx="20" cy="25" r="1.6" fill="#fff"/></svg></td>'
+            . '<td class="brand-copy"><strong>Испытательный центр</strong><span>АО «ЩЛЗ» · Портал заявок</span></td>'
+            . '</tr></table><h1>Экспертное заключение</h1>'
+            . '<p class="request-number">Заявка № ' . $data['number'] . '</p></header>'
+            . '<section class="section"><h2 class="section-title">Объект испытаний</h2><table class="facts"><tr>'
+            . '<td><span class="label">Наименование</span><span class="value">' . $escape($data['productName']) . '</span></td>'
+            . '<td><span class="label">Производитель</span><span class="value">' . $escape($data['manufacturer']) . '</span></td>'
+            . '<td><span class="label">Поставщик</span><span class="value">' . $escape($data['supplier']) . '</span></td>'
+            . '</tr></table></section>'
+            . '<section class="section"><h2 class="section-title">Заключение</h2>'
+            . '<p class="opinion">' . $escape($data['body']) . '</p></section>'
+            . '<table class="signoff"><tr><td class="expert"><span class="label">Эксперт</span>'
+            . '<span class="value">' . $escape($data['expertName']) . '</span>'
+            . '<span class="position">' . $escape($data['expertPosition']) . '</span></td>'
+            . '<td class="date"><span class="label">Дата</span><span class="value">' . $escape($data['date']) . '</span></td>'
+            . '</tr></table></body></html>';
     }
 }

--- a/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
+++ b/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
@@ -9,14 +9,36 @@ use PHPUnit\Framework\TestCase;
 
 final class OpinionPdfRendererTest extends TestCase
 {
-    public function testRendersPdfWithoutInterpretingUserHtml(): void
+    /** @return array{number: int, productName: string, manufacturer: string, supplier: string, expertName: string, expertPosition: string, body: string, date: string} */
+    private function documentData(): array
     {
-        $result = (new OpinionPdfRenderer())->render([
+        return [
             'number' => 42, 'productName' => '<b>Лифт</b>', 'manufacturer' => 'Завод',
             'supplier' => 'Поставщик', 'expertName' => 'Анна Смирнова',
             'expertPosition' => 'Эксперт', 'body' => '<script>alert(1)</script> Безопасное заключение',
             'date' => '28.07.2026',
-        ]);
+        ];
+    }
+
+    public function testRendersStyledHtmlWithoutInterpretingUserMarkup(): void
+    {
+        $html = (new OpinionPdfRenderer())->renderHtml($this->documentData());
+
+        self::assertStringContainsString('class="document-header"', $html);
+        self::assertStringContainsString('class="facts"', $html);
+        self::assertStringContainsString('class="opinion"', $html);
+        self::assertStringContainsString('class="signoff"', $html);
+        self::assertStringContainsString('fill="#253d98"', $html);
+        self::assertStringContainsString('Заявка № 42', $html);
+        self::assertStringContainsString('&lt;b&gt;Лифт&lt;/b&gt;', $html);
+        self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);
+        self::assertStringNotContainsString('<script>', $html);
+    }
+
+    public function testRendersPdf(): void
+    {
+        $result = (new OpinionPdfRenderer())->render($this->documentData());
+
         self::assertStringStartsWith('%PDF-', $result);
         self::assertGreaterThan(1000, strlen($result));
     }

--- a/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
+++ b/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
@@ -23,13 +23,16 @@ final class OpinionPdfRendererTest extends TestCase
     public function testRendersStyledHtmlWithoutInterpretingUserMarkup(): void
     {
         $html = (new OpinionPdfRenderer())->renderHtml($this->documentData());
+        $normalizedHtml = preg_replace('/\s+/', '', $html);
+
+        self::assertNotNull($normalizedHtml);
 
         self::assertStringContainsString('class="accent-rail"', $html);
         self::assertStringContainsString('class="document"', $html);
         self::assertStringContainsString('class="facts"', $html);
         self::assertStringContainsString('class="opinion"', $html);
         self::assertStringContainsString('class="signoff"', $html);
-        self::assertStringContainsString('background:#253d98', $html);
+        self::assertStringContainsString('background:#253d98', $normalizedHtml);
         self::assertStringContainsString('Заявка № 42', $html);
         self::assertStringContainsString('&lt;b&gt;Лифт&lt;/b&gt;', $html);
         self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);

--- a/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
+++ b/backend/tests/Unit/Infrastructure/Document/OpinionPdfRendererTest.php
@@ -24,11 +24,12 @@ final class OpinionPdfRendererTest extends TestCase
     {
         $html = (new OpinionPdfRenderer())->renderHtml($this->documentData());
 
-        self::assertStringContainsString('class="document-header"', $html);
+        self::assertStringContainsString('class="accent-rail"', $html);
+        self::assertStringContainsString('class="document"', $html);
         self::assertStringContainsString('class="facts"', $html);
         self::assertStringContainsString('class="opinion"', $html);
         self::assertStringContainsString('class="signoff"', $html);
-        self::assertStringContainsString('fill="#253d98"', $html);
+        self::assertStringContainsString('background:#253d98', $html);
         self::assertStringContainsString('Заявка № 42', $html);
         self::assertStringContainsString('&lt;b&gt;Лифт&lt;/b&gt;', $html);
         self::assertStringContainsString('&lt;script&gt;alert(1)&lt;/script&gt;', $html);


### PR DESCRIPTION
## Цель

Сделать экспертное заключение удобным для чтения, печати и архивирования, сохранив официальный сдержанный стиль портала.

## Что изменено

- добавлена структурированная шапка с фирменным знаком и номером заявки;
- сведения об объекте испытаний оформлены компактной таблицей фактов;
- заключение, эксперт, должность и дата разделены визуальными блоками;
- используется фирменный синий точечно, без фоновых заливок и внешних ресурсов;
- HTML-шаблон выделен для прямого тестирования структуры и экранирования пользовательских данных.

## Связанные правила и задачи

Closes #156

## Проверка

- `sh scripts/check.sh`;
- 190 backend-тестов, 308 assertions;
- 95 frontend-тестов;
- PHPStan, PHPCS, frontend lint/build/audit и repository lint проходят.

## Риски и откат

Риск низкий и ограничен визуальным представлением PDF. Данные, ACL и workflow не меняются. Откат — revert одного коммита.

## Метки

- [x] назначена ровно одна метка `type:*`;
- [x] назначены все применимые метки `area:*`;
- [x] назначена ровно одна метка `risk:*`;
- [ ] при необходимости добавлены `dependencies` и `breaking-change`.

## Готовность

- [x] тесты и обязательный pipeline проходят;
- [ ] Qodo завершил проверку текущего head-коммита: нет статуса `working`/`busy working`, опубликован итоговый `Code Review by Qodo`, все review threads закрыты (`resolved`);
- [x] документация и пользовательские инструкции актуализированы;
- [x] миграция и откат проверены, если изменялась база данных;
- [x] секреты и персональные данные не попали в код и логи.