### PR TITLE
refactor: reduce request controller boilerplate

### DIFF
--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -40,6 +40,7 @@ use App\Infrastructure\Document\OpinionPdfRenderer;
 use App\Infrastructure\Request\RequestQuery;
 use App\Infrastructure\Request\RequestRepository;
 use Yii;
+use yii\base\Model;
 use yii\rest\Controller;
 use yii\web\Response;
 use yii\web\ConflictHttpException;
@@ -104,10 +105,8 @@ final class RequestController extends Controller
     public function actionAddComment(int $id): array
     {
         $input = new AddCommentInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         try {
@@ -226,10 +225,8 @@ final class RequestController extends Controller
     public function actionDeleteReport(int $id): array
     {
         $input = new LockVersionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -302,10 +299,8 @@ final class RequestController extends Controller
     public function actionCreate(): array
     {
         $input = new CreateRequestInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -324,10 +319,8 @@ final class RequestController extends Controller
     public function actionSetColor(int $id): array
     {
         $input = new SetColorInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -349,10 +342,8 @@ final class RequestController extends Controller
     public function actionAssignExecutor(int $id): array
     {
         $input = new AssignExecutorInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $executorId = (int) $input->executorId;
@@ -380,10 +371,8 @@ final class RequestController extends Controller
     public function actionClaimExpert(int $id): array
     {
         $input = new LockVersionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -404,10 +393,8 @@ final class RequestController extends Controller
     public function actionReassignExpert(int $id): array
     {
         $input = new AssignExpertInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $expertId = (int) $input->expertId;
@@ -429,10 +416,8 @@ final class RequestController extends Controller
     public function actionPublishOpinion(int $id): array
     {
         $input = new PublishOpinionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -459,10 +444,8 @@ final class RequestController extends Controller
     public function actionSecurityDecision(int $id): array
     {
         $input = new SecurityDecisionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -489,10 +472,8 @@ final class RequestController extends Controller
     public function actionStart(int $id): array
     {
         $input = new LockVersionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -513,10 +494,8 @@ final class RequestController extends Controller
     public function actionSuspend(int $id): array
     {
         $input = new LockVersionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -539,10 +518,8 @@ final class RequestController extends Controller
     public function actionResume(int $id): array
     {
         $input = new LockVersionInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -565,10 +542,8 @@ final class RequestController extends Controller
     public function actionReject(int $id): array
     {
         $input = new CancelRequestInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -594,10 +569,8 @@ final class RequestController extends Controller
     public function actionWithdraw(int $id): array
     {
         $input = new CancelRequestInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $actorId = $this->currentUserId();
@@ -621,91 +594,62 @@ final class RequestController extends Controller
 
     private function recordRejectedCreateSafely(int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedCreate($actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого создания заявки.',
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedCreate($actorId, $ruleId),
+            'Не удалось записать аудит отклонённого создания заявки.',
+            ['actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedStartSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedStart($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого запуска заявки.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedStart($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого запуска заявки.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedSuspendResumeSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedSuspendResume($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённой приостановки/возобновления заявки.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedSuspendResume($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённой приостановки/возобновления заявки.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedRejectSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedReject($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого отказа в испытаниях.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedReject($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого отказа в испытаниях.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedWithdrawSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedWithdraw($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого отзыва заявки.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedWithdraw($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого отзыва заявки.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedColorSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->repository()->recordRejectedColor($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённой цветовой метки.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedColor($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённой цветовой метки.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedAssignmentSafely(
@@ -714,18 +658,17 @@ final class RequestController extends Controller
         int $actorId,
         string $ruleId,
     ): void {
-        try {
-            $this->repository()->recordRejectedAssignment($requestId, $executorId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого назначения.',
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedAssignment($requestId, $executorId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого назначения.',
+            [
                 'requestId' => $requestId,
                 'executorId' => $executorId,
                 'actorId' => $actorId,
                 'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+            ],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedExpertAssignmentSafely(
@@ -734,93 +677,99 @@ final class RequestController extends Controller
         int $actorId,
         string $ruleId,
     ): void {
-        try {
-            $this->repository()->recordRejectedExpertAssignment($requestId, $expertId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого назначения эксперта.',
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedExpertAssignment($requestId, $expertId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого назначения эксперта.',
+            [
                 'requestId' => $requestId,
                 'expertId' => $expertId,
                 'actorId' => $actorId,
                 'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+            ],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedDownloadSafely(int $versionId, int $actorId, string $reason): void
     {
-        try {
-            $this->documents()->recordRejectedDownload($versionId, $actorId, $reason);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого скачивания.',
-                'versionId' => $versionId,
-                'actorId' => $actorId,
-                'reason' => $reason,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->documents()->recordRejectedDownload($versionId, $actorId, $reason),
+            'Не удалось записать аудит отклонённого скачивания.',
+            ['versionId' => $versionId, 'actorId' => $actorId, 'reason' => $reason],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedReportSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->documents()->recordRejectedReportUpload($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённой загрузки отчёта.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->documents()->recordRejectedReportUpload($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённой загрузки отчёта.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedReportDeletionSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->documents()->recordRejectedReportDeletion($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого удаления отчёта.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->documents()->recordRejectedReportDeletion($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого удаления отчёта.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedOpinionSafely(int $requestId, int $actorId, string $ruleId): void
     {
-        try {
-            $this->documents()->recordRejectedOpinion($requestId, $actorId, $ruleId);
-        } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённой публикации заключения.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
-        }
+        $this->recordRejectedSafely(
+            fn () => $this->documents()->recordRejectedOpinion($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённой публикации заключения.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
     }
 
     private function recordRejectedSecurityDecisionSafely(int $requestId, int $actorId, string $ruleId): void
     {
+        $this->recordRejectedSafely(
+            fn () => $this->repository()->recordRejectedSecurityDecision($requestId, $actorId, $ruleId),
+            'Не удалось записать аудит отклонённого решения СБ.',
+            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            __METHOD__,
+        );
+    }
+
+    /**
+     * @param callable(): void $record
+     * @param array<string, int|string> $context
+     */
+    private function recordRejectedSafely(
+        callable $record,
+        string $message,
+        array $context,
+        string $category,
+    ): void {
         try {
-            $this->repository()->recordRejectedSecurityDecision($requestId, $actorId, $ruleId);
+            $record();
         } catch (\Throwable $auditError) {
-            Yii::error([
-                'message' => 'Не удалось записать аудит отклонённого решения СБ.',
-                'requestId' => $requestId,
-                'actorId' => $actorId,
-                'ruleId' => $ruleId,
-                'exception' => $auditError,
-            ], __METHOD__);
+            Yii::error(
+                ['message' => $message, ...$context, 'exception' => $auditError],
+                $category,
+            );
         }
+    }
+
+    /** @return array{errors: array<string, list<string>>}|null */
+    private function bodyValidationErrors(Model $input): ?array
+    {
+        $input->load(Yii::$app->request->bodyParams, '');
+        if ($input->validate()) {
+            return null;
+        }
+
+        Yii::$app->response->statusCode = 422;
+        return ['errors' => $input->getErrors()];
     }
 
     private function currentUserId(): int

--- a/backend/tests/Unit/Http/Controller/RequestControllerTest.php
+++ b/backend/tests/Unit/Http/Controller/RequestControllerTest.php
@@ -1,0 +1,63 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Http\Controller;
+
+use App\Http\Controller\RequestController;
+use PHPUnit\Framework\TestCase;
+use Yii;
+use yii\web\Application;
+use yii\web\Request;
+
+final class RequestControllerTest extends TestCase
+{
+    protected function tearDown(): void
+    {
+        Yii::$app?->errorHandler->unregister();
+        Yii::$app = null;
+        parent::tearDown();
+    }
+
+    public function testStartReturnsExistingValidationContract(): void
+    {
+        $controller = $this->controllerWithBody([]);
+
+        self::assertSame(
+            ['errors' => ['lockVersion' => ['Lock Version cannot be blank.']]],
+            $controller->actionStart(10),
+        );
+        self::assertSame(422, Yii::$app->response->statusCode);
+    }
+
+    public function testRejectReturnsErrorsForItsOwnInputFields(): void
+    {
+        $controller = $this->controllerWithBody([
+            'lockVersion' => 0,
+            'reason' => str_repeat('a', 5001),
+        ]);
+
+        $response = $controller->actionReject(10);
+
+        self::assertSame(['reason', 'lockVersion'], array_keys($response['errors']));
+        self::assertSame(422, Yii::$app->response->statusCode);
+    }
+
+    /** @param array<string, mixed> $body */
+    private function controllerWithBody(array $body): RequestController
+    {
+        $application = new Application([
+            'id' => 'request-controller-test',
+            'basePath' => dirname(__DIR__, 4),
+            'components' => [
+                'request' => [
+                    'class' => Request::class,
+                    'cookieValidationKey' => 'request-controller-test',
+                ],
+            ],
+        ]);
+        $application->request->setBodyParams($body);
+
+        return new RequestController('request', $application);
+    }
+}


### PR DESCRIPTION
## Цель

Уменьшить повторяющийся технический код в `RequestController`, не меняя HTTP-контракты и не вводя новый архитектурный слой.

## Что изменено

- одинаковая загрузка и валидация body Input DTO в 14 actions сведена к `bodyValidationErrors()`;
- 13 одинаковых `try/catch` вокруг записи rejected audit сведены к одному `recordRejectedSafely()`;
- содержательные wrappers rejected audit сохранены: в них по-прежнему явно видны операция, payload, сообщение и категория лога;
- добавлены controller-level тесты прежнего validation response для разных DTO;
- `RequestController` сокращён с 850 до 799 строк.

Сознательно не объединялись контекстные exception paths, success responses, query-параметры, upload validation и короткие factories repository/query/document dependencies: их контракты или бизнес-смысл различаются.

## Связанные правила и задачи

Отдельных бизнес-правил PR не меняет. Audit semantics, optimistic locking, workflow, outbox и notification delivery остаются прежними.

## Проверка

Локально подтверждено:

- `make check` — успешно;
- Backend Unit — 227 тестов, 367 assertions;
- PHPStan — успешно;
- PHPCS/lint — успешно;
- Composer validate/audit — успешно, advisories не найдены;
- Vitest — 96 тестов;
- frontend production build — успешно;
- `make e2e` — успешно: Playwright 9/9 и runtime contracts LDAP, SMTP recovery, MariaDB reconnect, scheduler SIGTERM;
- `git diff --check` — успешно.

`make test` дважды прошёл весь `check`, но агрегирующий запуск E2E остановился при получении metadata базового PHP image из Docker Hub (`EOF`). Тот же E2E/runtime-контур после первого сбоя был запущен отдельно и завершился успешно.

## Риски и откат

Риск ограничен локальной механикой controller validation и best-effort rejected audit. Формат validation errors, HTTP 422 и контекст каждого audit события сохранены. Откат — revert одного коммита; миграции и данные не менялись.

## Метки

- [ ] назначена ровно одна метка `type:*`;
- [ ] назначены все применимые метки `area:*`;
- [ ] назначена ровно одна метка `risk:*`;
- [ ] при необходимости добавлены `dependencies` и `breaking-change`.

## Готовность

- [x] тесты и обязательный pipeline проходят;
- [x] Qodo завершил проверку текущего head-коммита: нет статуса `working`/`busy working`, опубликован итоговый `Code Review by Qodo`, все review threads закрыты (`resolved`);
- [x] документация и пользовательские инструкции не требуют изменений;
- [x] база данных и миграции не изменялись;
- [x] секреты и персональные данные не попали в код и логи.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved request validation consistency across start and reject actions.
  * Preserved clear validation errors with HTTP 422 responses.
  * Improved reliability of audit logging when actions are rejected.

* **Tests**
  * Added coverage for request validation responses and error handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->