### PR TITLE
refactor: унифицировать контракт JSON request body

### DIFF
--- a/backend/src/Http/Controller/AdminController.php
+++ b/backend/src/Http/Controller/AdminController.php
@@ -13,12 +13,11 @@ use App\Domain\Identity\UserAdministrationTargetNotFound;
 use App\Infrastructure\Identity\CurrentUser;
 use App\Infrastructure\Identity\UserAdministrationRepository;
 use Yii;
-use yii\rest\Controller;
 use yii\web\ConflictHttpException;
 use yii\web\ForbiddenHttpException;
 use yii\web\NotFoundHttpException;
 
-final class AdminController extends Controller
+final class AdminController extends ApiController
 {
     public function behaviors(): array
     {
@@ -55,10 +54,8 @@ final class AdminController extends Controller
         $actorId = $this->authorize();
 
         $input = new CreateUserInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         $displayName = trim((string) $input->displayName);
@@ -86,10 +83,8 @@ final class AdminController extends Controller
         $actorId = $this->authorize();
 
         $input = new AssignRoleInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         try {

--- a/backend/src/Http/Controller/ApiController.php
+++ b/backend/src/Http/Controller/ApiController.php
@@ -17,7 +17,7 @@ abstract class ApiController extends Controller
     protected function bodyValidationErrors(Model $input): ?array
     {
         $request = Yii::$app->request;
-        $contentType = strtolower(trim(explode(';', $request->contentType, 2)[0]));
+        $contentType = strtolower(trim(explode(';', $request->contentType ?? '', 2)[0]));
         if ($contentType !== 'application/json') {
             throw new UnsupportedMediaTypeHttpException('Content-Type must be application/json.');
         }

--- a/backend/src/Http/Controller/ApiController.php
+++ b/backend/src/Http/Controller/ApiController.php
@@ -1,0 +1,48 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Http\Controller;
+
+use JsonException;
+use Yii;
+use yii\base\Model;
+use yii\rest\Controller;
+use yii\web\BadRequestHttpException;
+use yii\web\UnsupportedMediaTypeHttpException;
+
+abstract class ApiController extends Controller
+{
+    /** @return array{errors: array<string, list<string>>}|null */
+    protected function bodyValidationErrors(Model $input): ?array
+    {
+        $request = Yii::$app->request;
+        $contentType = strtolower(trim(explode(';', $request->contentType, 2)[0]));
+        if ($contentType !== 'application/json') {
+            throw new UnsupportedMediaTypeHttpException('Content-Type must be application/json.');
+        }
+
+        $rawBody = $request->rawBody;
+        if (trim($rawBody) === '') {
+            throw new BadRequestHttpException('Request body must not be empty.');
+        }
+
+        try {
+            $body = json_decode($rawBody, true, 512, JSON_THROW_ON_ERROR);
+        } catch (JsonException) {
+            throw new BadRequestHttpException('Malformed JSON request body.');
+        }
+
+        if (!is_array($body) || !str_starts_with(ltrim($rawBody), '{')) {
+            throw new BadRequestHttpException('Request body must be a JSON object.');
+        }
+
+        $input->load($body, '');
+        if ($input->validate()) {
+            return null;
+        }
+
+        Yii::$app->response->statusCode = 422;
+        return ['errors' => $input->getErrors()];
+    }
+}

--- a/backend/src/Http/Controller/AuthController.php
+++ b/backend/src/Http/Controller/AuthController.php
@@ -12,10 +12,9 @@ use App\Infrastructure\Identity\LdapAuthenticator;
 use App\Infrastructure\Ldap\LdapConnectionException;
 use App\Infrastructure\Ldap\NativeLdapClient;
 use Yii;
-use yii\rest\Controller;
 use yii\web\ServerErrorHttpException;
 
-final class AuthController extends Controller
+final class AuthController extends ApiController
 {
     public function behaviors(): array
     {
@@ -58,10 +57,8 @@ final class AuthController extends Controller
     public function actionLogin(): array
     {
         $input = new LoginInput();
-        $input->load(Yii::$app->request->bodyParams, '');
-        if (!$input->validate()) {
-            Yii::$app->response->statusCode = 422;
-            return ['errors' => $input->getErrors()];
+        if (($errors = $this->bodyValidationErrors($input)) !== null) {
+            return $errors;
         }
 
         try {

--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -40,8 +40,6 @@ use App\Infrastructure\Document\OpinionPdfRenderer;
 use App\Infrastructure\Request\RequestQuery;
 use App\Infrastructure\Request\RequestRepository;
 use Yii;
-use yii\base\Model;
-use yii\rest\Controller;
 use yii\web\Response;
 use yii\web\ConflictHttpException;
 use yii\web\ForbiddenHttpException;
@@ -49,7 +47,7 @@ use yii\web\NotFoundHttpException;
 use yii\web\ServerErrorHttpException;
 use yii\web\UploadedFile;
 
-final class RequestController extends Controller
+final class RequestController extends ApiController
 {
     public function behaviors(): array
     {
@@ -758,18 +756,6 @@ final class RequestController extends Controller
                 $category,
             );
         }
-    }
-
-    /** @return array{errors: array<string, list<string>>}|null */
-    private function bodyValidationErrors(Model $input): ?array
-    {
-        $input->load(Yii::$app->request->bodyParams, '');
-        if ($input->validate()) {
-            return null;
-        }
-
-        Yii::$app->response->statusCode = 422;
-        return ['errors' => $input->getErrors()];
     }
 
     private function currentUserId(): int

--- a/backend/tests/Integration/Http/JsonBodyContractTest.php
+++ b/backend/tests/Integration/Http/JsonBodyContractTest.php
@@ -1,0 +1,185 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Http;
+
+use App\Http\Controller\AdminController;
+use App\Http\Controller\AuthController;
+use App\Http\Controller\RequestController;
+use PHPUnit\Framework\Attributes\DataProvider;
+use Tests\Integration\IntegrationTestCase;
+use Yii;
+use yii\web\Application;
+use yii\web\BadRequestHttpException;
+use yii\web\Request;
+use yii\web\UnauthorizedHttpException;
+use yii\web\UnsupportedMediaTypeHttpException;
+
+final class JsonBodyContractTest extends IntegrationTestCase
+{
+    protected function tearDown(): void
+    {
+        Yii::$app?->errorHandler->unregister();
+        Yii::$app = null;
+        parent::tearDown();
+    }
+
+    /** @param array<string, list<string>> $expectedErrors */
+    #[DataProvider('controllerProvider')]
+    public function testValidJsonObjectUsesExistingDtoValidation(
+        string $controller,
+        array $expectedErrors,
+    ): void {
+        $this->createApplication('{}', 'application/json');
+
+        $response = $this->invokeAction($controller);
+
+        self::assertSame(['errors' => $expectedErrors], $response);
+        self::assertSame(422, Yii::$app->response->statusCode);
+    }
+
+    /** @param array<string, list<string>> $expectedErrors */
+    #[DataProvider('controllerProvider')]
+    public function testJsonContentTypeWithCharsetIsAccepted(
+        string $controller,
+        array $expectedErrors,
+    ): void {
+        $this->createApplication('{}', 'application/json; charset=UTF-8');
+
+        self::assertSame(['errors' => $expectedErrors], $this->invokeAction($controller));
+        self::assertSame(422, Yii::$app->response->statusCode);
+    }
+
+    #[DataProvider('invalidJsonBodyProvider')]
+    public function testInvalidJsonBodyReturnsBadRequestForEveryController(
+        string $controller,
+        string $body,
+        string $expectedMessage,
+    ): void {
+        $this->createApplication($body, 'application/json');
+
+        try {
+            $this->invokeAction($controller);
+            self::fail('Expected invalid JSON body to be rejected.');
+        } catch (BadRequestHttpException $exception) {
+            self::assertSame(400, $exception->statusCode);
+            self::assertSame($expectedMessage, $exception->getMessage());
+        }
+    }
+
+    #[DataProvider('unsupportedContentTypeProvider')]
+    public function testUnsupportedContentTypeReturnsSameResponseForEveryController(
+        string $controller,
+        ?string $contentType,
+    ): void {
+        $this->createApplication('{}', $contentType);
+
+        try {
+            $this->invokeAction($controller);
+            self::fail('Expected unsupported Content-Type to be rejected.');
+        } catch (UnsupportedMediaTypeHttpException $exception) {
+            self::assertSame(415, $exception->statusCode);
+            self::assertSame('Content-Type must be application/json.', $exception->getMessage());
+        }
+    }
+
+    public function testAdminAuthorizationStillPrecedesBodyValidation(): void
+    {
+        $this->createApplication('{}', 'application/json');
+        Yii::$app->request->headers->remove('X-Test-User-ID');
+
+        $this->expectException(UnauthorizedHttpException::class);
+        $this->expectExceptionMessage('Authentication required');
+
+        (new AdminController('admin', Yii::$app))->actionCreateUser();
+    }
+
+    /** @return iterable<string, array{string, array<string, list<string>>}> */
+    public static function controllerProvider(): iterable
+    {
+        yield 'request' => [
+            'request',
+            ['lockVersion' => ['Lock Version cannot be blank.']],
+        ];
+        yield 'admin' => [
+            'admin',
+            ['adLogin' => ['Ad Login cannot be blank.']],
+        ];
+        yield 'auth' => [
+            'auth',
+            [
+                'login' => ['Login cannot be blank.'],
+                'password' => ['Password cannot be blank.'],
+            ],
+        ];
+    }
+
+    /** @return iterable<string, array{string, string, string}> */
+    public static function invalidJsonBodyProvider(): iterable
+    {
+        $cases = [
+            'empty' => ['', 'Request body must not be empty.'],
+            'whitespace' => [" \n\t", 'Request body must not be empty.'],
+            'malformed' => ['{"lockVersion":', 'Malformed JSON request body.'],
+            'empty array' => ['[]', 'Request body must be a JSON object.'],
+            'array' => ['[{"lockVersion":1}]', 'Request body must be a JSON object.'],
+            'string' => ['"value"', 'Request body must be a JSON object.'],
+            'number' => ['123', 'Request body must be a JSON object.'],
+            'boolean' => ['true', 'Request body must be a JSON object.'],
+            'null' => ['null', 'Request body must be a JSON object.'],
+        ];
+
+        foreach (array_keys(iterator_to_array(self::controllerProvider())) as $controller) {
+            foreach ($cases as $case => [$body, $message]) {
+                yield $controller . ': ' . $case => [$controller, $body, $message];
+            }
+        }
+    }
+
+    /** @return iterable<string, array{string, string|null}> */
+    public static function unsupportedContentTypeProvider(): iterable
+    {
+        foreach (array_keys(iterator_to_array(self::controllerProvider())) as $controller) {
+            yield $controller . ': missing' => [$controller, null];
+            yield $controller . ': text/plain' => [$controller, 'text/plain'];
+        }
+    }
+
+    private function createApplication(string $body, ?string $contentType): void
+    {
+        $actorId = $this->createUser(uniqid('json-contract-', true), 'JSON contract admin');
+        $this->grantRole($actorId, 'administrator');
+
+        $application = new Application([
+            'id' => 'json-body-contract-test',
+            'basePath' => dirname(__DIR__, 4),
+            'params' => [
+                'identityHeader' => 'X-Test-User-ID',
+            ],
+            'components' => [
+                'db' => $this->db(),
+                'request' => [
+                    'class' => Request::class,
+                    'cookieValidationKey' => 'json-body-contract-test',
+                ],
+            ],
+        ]);
+        if ($contentType !== null) {
+            $application->request->headers->set('Content-Type', $contentType);
+        }
+        $application->request->headers->set('X-Test-User-ID', (string) $actorId);
+        $application->request->setRawBody($body);
+    }
+
+    /** @return array<string, mixed> */
+    private function invokeAction(string $controller): array
+    {
+        return match ($controller) {
+            'request' => (new RequestController('request', Yii::$app))->actionStart(10),
+            'admin' => (new AdminController('admin', Yii::$app))->actionCreateUser(),
+            'auth' => (new AuthController('auth', Yii::$app))->actionLogin(),
+            default => self::fail('Unknown controller case: ' . $controller),
+        };
+    }
+}

--- a/backend/tests/Unit/Http/Controller/RequestControllerTest.php
+++ b/backend/tests/Unit/Http/Controller/RequestControllerTest.php
@@ -56,7 +56,8 @@ final class RequestControllerTest extends TestCase
                 ],
             ],
         ]);
-        $application->request->setBodyParams($body);
+        $application->request->headers->set('Content-Type', 'application/json');
+        $application->request->setRawBody(json_encode((object) $body, JSON_THROW_ON_ERROR));
 
         return new RequestController('request', $application);
     }

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,6 +10,15 @@
 Обычная авторизация использует `POST /api/v1/auth/login` с LDAP login/password
 и серверную session cookie.
 
+Все POST-запросы этих контроллеров принимают непустой JSON object с
+`Content-Type: application/json` (параметр `charset` допускается):
+
+- отсутствующий или другой `Content-Type` возвращает `415`;
+- пустое или некорректное JSON-тело возвращает `400`;
+- JSON array, scalar и `null` возвращают `400`;
+- корректный JSON object, не прошедший валидацию DTO, сохраняет прежний ответ
+  `422` в формате `{"errors": {...}}`.
+
 Development deployment дополнительно монтирует маршруты:
 
 - `GET /api/v1/dev/users` — безопасный список активных seeded users;

--- a/docs/api.md
+++ b/docs/api.md
@@ -10,14 +10,18 @@
 Обычная авторизация использует `POST /api/v1/auth/login` с LDAP login/password
 и серверную session cookie.
 
-Все POST-запросы этих контроллеров принимают непустой JSON object с
-`Content-Type: application/json` (параметр `charset` допускается):
+POST-маршруты, принимающие DTO в JSON, требуют непустое тело в формате JSON
+object с `Content-Type: application/json` (параметр `charset` допускается):
 
 - отсутствующий или другой `Content-Type` возвращает `415`;
 - пустое или некорректное JSON-тело возвращает `400`;
 - JSON array, scalar и `null` возвращают `400`;
+- `{}` проходит разбор JSON object и передаётся в DTO validation;
 - корректный JSON object, не прошедший валидацию DTO, сохраняет прежний ответ
   `422` в формате `{"errors": {...}}`.
+
+Маршруты без DTO body, включая logout и отзыв роли, этого тела не требуют.
+Загрузка документов и отчётов использует `multipart/form-data`.
 
 Development deployment дополнительно монтирует маршруты:
 


### PR DESCRIPTION
## Цель

Унифицировать чтение JSON request body и формат DTO validation errors в `RequestController`, `AdminController` и `AuthController` без изменения маршрутов, DTO или бизнес-логики.

## Найденные различия до изменения

- `RequestController` использовал собственный `bodyValidationErrors()`, а Admin/Auth повторяли `load + validate + 422` непосредственно в actions.
- Ни один контроллер явно не различал JSON object и top-level array/scalar/null; scalar мог приводить к `TypeError` вместо согласованного HTTP-ответа.
- Пустое тело фактически смешивалось с пустым object и доходило до DTO validation.
- Malformed JSON зависел от поведения Yii parser, а отсутствие/неверный `Content-Type` не имело явного общего контракта.
- В Admin авторизация выполнялась до DTO validation. Этот порядок сохранён как security-семантика.

## Реализация

Добавлен компактный `ApiController`, содержащий только общий технический helper `bodyValidationErrors()`:

| Вход | Результат |
|---|---|
| JSON object | загрузка DTO и обычная обработка |
| пустое/whitespace body | `400 Request body must not be empty.` |
| malformed JSON | `400 Malformed JSON request body.` |
| array/scalar/null | `400 Request body must be a JSON object.` |
| отсутствующий или отличный от `application/json` Content-Type | `415 Content-Type must be application/json.` |
| `application/json` с charset | принимается |
| DTO validation error | прежний `422 {"errors": ...}` |

Admin authorization по-прежнему предшествует body validation. Поэтому неавторизованный Admin-вызов сохраняет прежний `401`, а приведённый JSON-контракт применяется после успешной авторизации.

## Тесты

Добавлен integration-набор, который проверяет Request/Admin/Auth для:

- валидного JSON object и прежнего ValidationError;
- Content-Type с charset;
- пустого тела и whitespace;
- malformed JSON;
- пустого и непустого массива;
- string/number/boolean/null;
- отсутствующего и неверного Content-Type;
- сохранённого приоритета Admin authorization.

## Изменения контракта

Маршруты, DTO, успешные ответы и DTO validation response не изменены. Изменено только поведение некорректного representation:

- пустое body теперь `400`, а не DTO `422`;
- top-level array/scalar/null теперь предсказуемо `400`;
- отсутствующий/неверный Content-Type теперь `415`;
- malformed JSON единообразно `400`.

## Локально подтверждено

- `make check` — успешно;
- `make test` — успешно;
- Backend Unit: 227 tests / 367 assertions;
- Backend Integration: 100 tests / 306 assertions;
- Vitest: 96 tests;
- Playwright: 9 scenarios;
- PHPStan, PHPCS, Composer validate/audit, frontend production build — успешно;
- LDAP, SMTP recovery, MariaDB reconnect, scheduler SIGTERM runtime contracts — успешно;
- `git diff --check` — успешно.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Standardized JSON request handling across authentication, administration, and request workflows.
  * Malformed, empty, or non-object JSON bodies now receive consistent error responses.
  * Unsupported content types are rejected consistently, while JSON content types with charsets are accepted.
  * Validation errors now use a uniform response format and status.
  * Authorization checks continue before request-body validation where required.

* **Documentation**
  * Documented JSON requirements, supported content types, and expected error responses.

* **Tests**
  * Added coverage for JSON validation, content types, authorization ordering, and controller responses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->