### PR TITLE
fix(dev): start user switcher after late module load

### DIFF
--- a/frontend/dev/dev-tools.js
+++ b/frontend/dev/dev-tools.js
@@ -65,9 +65,14 @@ export function renderUserSwitcher(browserWindow, document, users) {
 
 export function startDevelopmentTools(browserWindow, document) {
   const originalFetch = installIdentityFetch(browserWindow)
-  browserWindow.addEventListener('DOMContentLoaded', () => {
+  const loadSwitcher = () => {
     loadUsers(originalFetch)
       .then((result) => renderUserSwitcher(browserWindow, document, result.items))
       .catch((error) => console.error('Development tools failed:', error))
-  })
+  }
+  if (document.readyState === 'loading') {
+    browserWindow.addEventListener('DOMContentLoaded', loadSwitcher, { once: true })
+  } else {
+    loadSwitcher()
+  }
 }

--- a/frontend/dev/dev-tools.test.js
+++ b/frontend/dev/dev-tools.test.js
@@ -152,12 +152,48 @@ describe('standalone development tools', () => {
     expect(browser.location.reload).not.toHaveBeenCalled()
   })
 
-  it('starts after DOMContentLoaded and reports an unavailable endpoint', async () => {
+  it('renders the switcher after DOMContentLoaded when the document is loading', async () => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [{ id: 1, displayName: 'Manager', position: 'IC', roles: ['ic_manager'] }] }),
+    })
+    const browser = browserWindow(fetch)
+    browser.localStorage.setItem('ic.dev.userId', '1')
+    const body = element('body')
+    const document = { readyState: 'loading', body, createElement: (tag) => element(tag) }
+
+    startDevelopmentTools(browser, document)
+
+    expect(fetch).not.toHaveBeenCalled()
+    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
+    browser.addEventListener.mock.calls[0][1]()
+    await vi.waitFor(() => expect(body.children).toHaveLength(1))
+    expect(fetch).toHaveBeenCalledOnce()
+  })
+
+  it.each(['interactive', 'complete'])('renders the switcher immediately when readyState is %s', async (readyState) => {
+    const fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({ items: [{ id: 1, displayName: 'Manager', position: 'IC', roles: ['ic_manager'] }] }),
+    })
+    const browser = browserWindow(fetch)
+    browser.localStorage.setItem('ic.dev.userId', '1')
+    const body = element('body')
+    const document = { readyState, body, createElement: (tag) => element(tag) }
+
+    startDevelopmentTools(browser, document)
+
+    await vi.waitFor(() => expect(body.children).toHaveLength(1))
+    expect(fetch).toHaveBeenCalledOnce()
+    expect(browser.addEventListener).not.toHaveBeenCalled()
+  })
+
+  it('reports an unavailable endpoint after DOMContentLoaded', async () => {
     const browser = browserWindow(vi.fn().mockResolvedValue({ ok: false, status: 503 }))
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
-    startDevelopmentTools(browser, { body: element('body'), createElement: (tag) => element(tag) })
+    startDevelopmentTools(browser, { readyState: 'loading', body: element('body'), createElement: (tag) => element(tag) })
 
-    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function))
+    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
     browser.addEventListener.mock.calls[0][1]()
     await vi.waitFor(() => expect(error).toHaveBeenCalledWith(
       'Development tools failed:',

--- a/frontend/src/bootstrap.test.js
+++ b/frontend/src/bootstrap.test.js
@@ -23,7 +23,7 @@ describe('application bootstrap', () => {
   it('installs development identity before the first application request', async () => {
     const originalFetch = vi.fn().mockResolvedValue({ ok: true })
     const browser = browserWindow(originalFetch)
-    const document = {}
+    const document = { readyState: 'loading' }
 
     await bootstrapApplication({
       loadDevelopmentTools: developmentToolsLoader(
@@ -36,6 +36,6 @@ describe('application bootstrap', () => {
 
     expect(originalFetch).toHaveBeenCalledOnce()
     expect(originalFetch.mock.calls[0][1].headers.get('X-Dev-User-ID')).toBe('7')
-    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function))
+    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
   })
 })


### PR DESCRIPTION
## Цель

Вернуть development-панель выбора пользователя после late dynamic import dev-tools.

Closes #193

## Root cause

После `await import('../dev/dev-tools.js')` документ в реальном development build уже находится в состоянии `complete`. `startDevelopmentTools()` безусловно регистрировал listener `DOMContentLoaded`, но событие уже завершилось. Поэтому interceptor устанавливался, а `/api/v1/dev/users` и рендер панели никогда не запускались.

До исправления browser reproduction: chunk HTTP 200, Console errors 0, listener зарегистрирован при `readyState=complete`, dev-users requests 0, panels 0.

## Решение

- при `document.readyState === 'loading'` загрузка switcher ждёт однократный `DOMContentLoaded`;
- при `interactive` и `complete` загрузка запускается немедленно;
- dynamic import и установка identity interceptor до Vue mount сохранены;
- production bundle и Docker guards не менялись.

## Проверка

- focused Vitest: 14 passed;
- полный Vitest: 106 passed;
- frontend coverage: 98.41% lines;
- `make check`: passed, включая 232 backend tests;
- development runtime contract: passed;
- browser smoke после пересборки: panel 1, dev chunk 200, dev-users requests выполнены, Console errors 0;
- production build: passed.

## Риск и откат

Низкий риск: изменён только lifecycle development switcher и его тесты. Откат — revert commit; БД, backend auth и production runtime не затронуты.
