### PR TITLE
test(frontend): use precise browser API fakes for dev tools

### DIFF
--- a/frontend/dev/dev-tools.test.js
+++ b/frontend/dev/dev-tools.test.js
@@ -6,29 +6,13 @@ import {
   selectedUserId,
   startDevelopmentTools,
 } from './dev-tools'
+import { createDevToolsBrowserEnvironment } from '../test/browserEnvironment'
 
-function browserWindow(fetch = vi.fn()) {
-  const values = new Map()
+function browserEnvironment(fetch = vi.fn(), readyState = 'complete') {
+  const reload = vi.fn()
   return {
-    fetch,
-    addEventListener: vi.fn(),
-    location: { href: 'http://localhost:8080/requests', origin: 'http://localhost:8080', reload: vi.fn() },
-    localStorage: {
-      getItem: (key) => values.get(key) ?? null,
-      setItem: (key, value) => values.set(key, value),
-    },
-  }
-}
-
-function element(tag) {
-  return {
-    tag,
-    children: [],
-    style: {},
-    listeners: {},
-    setAttribute: vi.fn(),
-    append(child) { this.children.push(child) },
-    addEventListener(name, listener) { this.listeners[name] = listener },
+    ...createDevToolsBrowserEnvironment({ fetch, readyState, reload }),
+    reload,
   }
 }
 
@@ -51,7 +35,7 @@ describe('standalone development tools', () => {
 
   it('persists a valid selection and adds it only to same-origin API requests', async () => {
     const originalFetch = vi.fn().mockResolvedValue({ ok: true })
-    const browser = browserWindow(originalFetch)
+    const { browserWindow: browser } = browserEnvironment(originalFetch)
     browser.localStorage.setItem('ic.dev.userId', '7')
     installIdentityFetch(browser)
 
@@ -75,7 +59,7 @@ describe('standalone development tools', () => {
 
   it('does not add an identity header without a selected user', async () => {
     const originalFetch = vi.fn().mockResolvedValue({ ok: true })
-    const browser = browserWindow(originalFetch)
+    const { browserWindow: browser } = browserEnvironment(originalFetch)
     installIdentityFetch(browser)
 
     await browser.fetch('/api/v1/auth/me')
@@ -86,7 +70,7 @@ describe('standalone development tools', () => {
   it('supports string inputs when Request is unavailable', async () => {
     vi.stubGlobal('Request', undefined)
     const originalFetch = vi.fn().mockResolvedValue({ ok: true })
-    const browser = browserWindow(originalFetch)
+    const { browserWindow: browser } = browserEnvironment(originalFetch)
     browser.localStorage.setItem('ic.dev.userId', '7')
 
     try {
@@ -100,10 +84,8 @@ describe('standalone development tools', () => {
   })
 
   it('renders only safe display fields and switches identity after reload', () => {
-    const browser = browserWindow()
+    const { browserWindow: browser, document, reload } = browserEnvironment()
     browser.localStorage.setItem('ic.dev.userId', '1')
-    const body = element('body')
-    const document = { body, createElement: (tag) => element(tag) }
     renderUserSwitcher(browser, document, [{
       id: 1,
       displayName: 'Manager',
@@ -117,39 +99,37 @@ describe('standalone development tools', () => {
       roles: ['employee', 'ic_executor'],
     }])
 
-    const select = body.children[0].children[0].children[0]
+    const select = document.body.children[0].children[0].children[0]
     expect(select.children.map((option) => option.textContent)).toEqual([
       'Manager — IC [employee, administrator]',
       'Executor — Lab [employee, ic_executor]',
     ])
-    expect(JSON.stringify(body)).not.toContain('must-not-render@example.invalid')
+    expect(JSON.stringify(document.body)).not.toContain('must-not-render@example.invalid')
 
     select.value = '2'
-    select.listeners.change()
+    select.dispatchEvent(new Event('change'))
     expect(selectedUserId(browser)).toBe('2')
-    expect(browser.location.reload).toHaveBeenCalledOnce()
+    expect(reload).toHaveBeenCalledOnce()
   })
 
   it('replaces an invalid persisted selection with the first available user', () => {
-    const browser = browserWindow()
+    const { browserWindow: browser, document, reload } = browserEnvironment()
     browser.localStorage.setItem('ic.dev.userId', '999')
-    const body = element('body')
-    renderUserSwitcher(browser, { body, createElement: (tag) => element(tag) }, [
+    renderUserSwitcher(browser, document, [
       { id: 1, displayName: 'Manager', position: 'IC', roles: ['ic_manager'] },
     ])
 
     expect(selectedUserId(browser)).toBe('1')
-    expect(browser.location.reload).toHaveBeenCalledOnce()
-    expect(body.children).toEqual([])
+    expect(reload).toHaveBeenCalledOnce()
+    expect(document.body.children).toEqual([])
   })
 
   it('does not render a switcher for an empty user list', () => {
-    const browser = browserWindow()
-    const body = element('body')
-    renderUserSwitcher(browser, { body, createElement: (tag) => element(tag) }, [])
+    const { browserWindow: browser, document, reload } = browserEnvironment()
+    renderUserSwitcher(browser, document, [])
 
-    expect(body.children).toEqual([])
-    expect(browser.location.reload).not.toHaveBeenCalled()
+    expect(document.body.children).toEqual([])
+    expect(reload).not.toHaveBeenCalled()
   })
 
   it('renders the switcher after DOMContentLoaded when the document is loading', async () => {
@@ -157,17 +137,15 @@ describe('standalone development tools', () => {
       ok: true,
       json: async () => ({ items: [{ id: 1, displayName: 'Manager', position: 'IC', roles: ['ic_manager'] }] }),
     })
-    const browser = browserWindow(fetch)
+    const { browserWindow: browser, document, dispatchDOMContentLoaded } = browserEnvironment(fetch, 'loading')
     browser.localStorage.setItem('ic.dev.userId', '1')
-    const body = element('body')
-    const document = { readyState: 'loading', body, createElement: (tag) => element(tag) }
 
     startDevelopmentTools(browser, document)
 
     expect(fetch).not.toHaveBeenCalled()
-    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
-    browser.addEventListener.mock.calls[0][1]()
-    await vi.waitFor(() => expect(body.children).toHaveLength(1))
+    dispatchDOMContentLoaded()
+    await vi.waitFor(() => expect(document.body.children).toHaveLength(1))
+    dispatchDOMContentLoaded()
     expect(fetch).toHaveBeenCalledOnce()
   })
 
@@ -176,25 +154,24 @@ describe('standalone development tools', () => {
       ok: true,
       json: async () => ({ items: [{ id: 1, displayName: 'Manager', position: 'IC', roles: ['ic_manager'] }] }),
     })
-    const browser = browserWindow(fetch)
+    const { browserWindow: browser, document } = browserEnvironment(fetch, readyState)
     browser.localStorage.setItem('ic.dev.userId', '1')
-    const body = element('body')
-    const document = { readyState, body, createElement: (tag) => element(tag) }
 
     startDevelopmentTools(browser, document)
 
-    await vi.waitFor(() => expect(body.children).toHaveLength(1))
+    await vi.waitFor(() => expect(document.body.children).toHaveLength(1))
     expect(fetch).toHaveBeenCalledOnce()
-    expect(browser.addEventListener).not.toHaveBeenCalled()
   })
 
   it('reports an unavailable endpoint after DOMContentLoaded', async () => {
-    const browser = browserWindow(vi.fn().mockResolvedValue({ ok: false, status: 503 }))
+    const { browserWindow: browser, document, dispatchDOMContentLoaded } = browserEnvironment(
+      vi.fn().mockResolvedValue({ ok: false, status: 503 }),
+      'loading',
+    )
     const error = vi.spyOn(console, 'error').mockImplementation(() => {})
-    startDevelopmentTools(browser, { readyState: 'loading', body: element('body'), createElement: (tag) => element(tag) })
+    startDevelopmentTools(browser, document)
 
-    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
-    browser.addEventListener.mock.calls[0][1]()
+    dispatchDOMContentLoaded()
     await vi.waitFor(() => expect(error).toHaveBeenCalledWith(
       'Development tools failed:',
       expect.objectContaining({ message: 'Development users are unavailable (503)' }),

--- a/frontend/src/bootstrap.test.js
+++ b/frontend/src/bootstrap.test.js
@@ -1,15 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import { bootstrapApplication, developmentToolsLoader } from './bootstrap'
-
-function browserWindow(fetch) {
-  const values = new Map([['ic.dev.userId', '7']])
-  return {
-    fetch,
-    addEventListener: vi.fn(),
-    location: { href: 'http://localhost:8080/', origin: 'http://localhost:8080' },
-    localStorage: { getItem: (key) => values.get(key) ?? null },
-  }
-}
+import { createDevToolsBrowserEnvironment } from '../test/browserEnvironment'
 
 describe('application bootstrap', () => {
   it('starts the application directly without development tools', async () => {
@@ -22,8 +13,11 @@ describe('application bootstrap', () => {
 
   it('installs development identity before the first application request', async () => {
     const originalFetch = vi.fn().mockResolvedValue({ ok: true })
-    const browser = browserWindow(originalFetch)
-    const document = { readyState: 'loading' }
+    const { browserWindow: browser, document } = createDevToolsBrowserEnvironment({
+      fetch: originalFetch,
+      readyState: 'loading',
+    })
+    browser.localStorage.setItem('ic.dev.userId', '7')
 
     await bootstrapApplication({
       loadDevelopmentTools: developmentToolsLoader(
@@ -36,6 +30,5 @@ describe('application bootstrap', () => {
 
     expect(originalFetch).toHaveBeenCalledOnce()
     expect(originalFetch.mock.calls[0][1].headers.get('X-Dev-User-ID')).toBe('7')
-    expect(browser.addEventListener).toHaveBeenCalledWith('DOMContentLoaded', expect.any(Function), { once: true })
   })
 })

--- a/frontend/test/browserEnvironment.js
+++ b/frontend/test/browserEnvironment.js
@@ -1,0 +1,65 @@
+class MemoryStorage {
+  #values = new Map()
+
+  getItem(key) {
+    return this.#values.get(String(key)) ?? null
+  }
+
+  setItem(key, value) {
+    this.#values.set(String(key), String(value))
+  }
+}
+
+class TestElement extends EventTarget {
+  constructor(tagName) {
+    super()
+    this.tagName = tagName.toUpperCase()
+    this.children = []
+    this.style = { cssText: '' }
+    this.textContent = ''
+    this.value = ''
+    this.selected = false
+    this.attributes = new Map()
+  }
+
+  append(...children) {
+    this.children.push(...children)
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value))
+  }
+}
+
+export function createDevToolsBrowserEnvironment({ fetch, readyState = 'complete', reload = () => {} } = {}) {
+  const events = new EventTarget()
+  let currentReadyState = readyState
+  const document = {
+    body: new TestElement('body'),
+    createElement: (tagName) => new TestElement(tagName),
+    get readyState() {
+      return currentReadyState
+    },
+  }
+  const browserWindow = {
+    fetch,
+    localStorage: new MemoryStorage(),
+    location: {
+      href: 'http://localhost:8080/requests',
+      origin: 'http://localhost:8080',
+      reload,
+    },
+    addEventListener: events.addEventListener.bind(events),
+    removeEventListener: events.removeEventListener.bind(events),
+    dispatchEvent: events.dispatchEvent.bind(events),
+  }
+
+  return {
+    browserWindow,
+    document,
+    dispatchDOMContentLoaded() {
+      currentReadyState = 'interactive'
+      browserWindow.dispatchEvent(new Event('DOMContentLoaded'))
+    },
+  }
+}

--- a/frontend/test/browserEnvironment.js
+++ b/frontend/test/browserEnvironment.js
@@ -32,6 +32,8 @@ class TestElement extends EventTarget {
 }
 
 export function createDevToolsBrowserEnvironment({ fetch, readyState = 'complete', reload = () => {} } = {}) {
+  if (typeof fetch !== 'function') throw new TypeError('fetch must be a function')
+
   const events = new EventTarget()
   let currentReadyState = readyState
   const document = {


### PR DESCRIPTION
## Summary

- replace hand-invoked DOM lifecycle callbacks with a focused dev-tools browser test factory backed by the runtime EventTarget
- exercise DOMContentLoaded and change through dispatchEvent, including once semantics
- share the narrow localStorage, document, and location contract with the bootstrap regression test

## Scope

- test code only
- no production behavior changes
- no new dependencies

## Validation

- npm test -- --run dev/dev-tools.test.js src/bootstrap.test.js
- npm test
- npm run lint
- npm run build
- git diff --check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved browser-based test coverage for identity headers, safe rendering, selection persistence, loading states, document readiness, page reloads, and unavailable endpoints.
  * Added shared browser test environment support with in-memory storage, configurable requests, DOM events, and reload handling.
  * Standardized bootstrap and developer tools tests on realistic browser interactions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->