### PR TITLE
Документировать состав демонстрационных заявок

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -110,7 +110,11 @@ Development deployment дополнительно монтирует маршр�
 
 - `GET /api/v1/dev/users` — безопасный список активных seeded users;
 - `POST /api/v1/dev/seed-requests` — подготовка development-данных; запрос
-  требует выбранного активного пользователя с ролью `administrator`.
+  требует выбранного активного пользователя с ролью `administrator`, удаляет
+  прежние данные заявок и создаёт 100 синтетических заявок на всех стадиях.
+  Набор включает обсуждения разной длины, сопроводительные документы в форматах
+  PDF, PNG, JPG, JPEG, DOCX и XLSX, а также PDF-отчёты и PDF-заключения. Успешный
+  ответ содержит счётчики `requests`, `comments` и `documents`.
 
 Они отсутствуют в production и test route table. Header `X-Dev-User-ID`
 принимается только когда `compose.dev.yaml` смонтировал development


### PR DESCRIPTION
Closes #210

## Цель

Зафиксировать в API-документации фактический контракт кнопки «Заполнить демо». Реализация генерации 100 качественных заявок уже доставлена в `main` через #209; этот PR устраняет оставшийся разрыв в документации.

## Что изменено

- указано, что development seed удаляет прежние данные заявок и создаёт 100 синтетических заявок на всех стадиях;
- перечислены форматы сопроводительных документов: PDF, PNG, JPG, JPEG, DOCX и XLSX;
- закреплены PDF-форматы отчётов и экспертных заключений;
- описаны счётчики успешного ответа: `requests`, `comments`, `documents`.

## Риски

Низкие: изменяется только документация development endpoint. Production routes, данные и workflow не затрагиваются.

## Проверка

- pre-push `make check` — успешно:
  - OpenAPI validation;
  - ESLint и npm audit;
  - Vitest: 173/173;
  - Composer validate, lint, PHPStan и audit;
  - PHPUnit: 284/284, 537 assertions;
  - repository contracts и Markdown lint;
- `git diff --check` — успешно.

## Откат

Откатить единственный commit PR; runtime-откат не требуется.