### PR TITLE
Исправить авторов и статусы демонстрационных заявок

### DIFF
--- a/backend/src/Console/DevController.php
+++ b/backend/src/Console/DevController.php
@@ -40,7 +40,7 @@ final class DevController extends Controller
         4 => [
             'ad_login' => 'dev.expert', 'display_name' => 'Анна Смирнова',
             'email' => 'dev.expert@example.invalid', 'position' => 'Эксперт',
-            'department' => 'Испытательный центр', 'roles' => ['employee', 'expert'],
+            'department' => 'СГК', 'roles' => ['employee', 'expert'],
         ],
         5 => [
             'ad_login' => 'dev.security', 'display_name' => 'Олег Воронцов',
@@ -107,7 +107,7 @@ final class DevController extends Controller
     private const ADDITIONAL_EXPERTS = [
         'dev.expert2' => [
             'display_name' => 'Виктор Дорохов', 'email' => 'dev.expert2@example.invalid',
-            'position' => 'Эксперт', 'department' => 'Испытательный центр', 'roles' => ['employee', 'expert'],
+            'position' => 'Эксперт', 'department' => 'СГК', 'roles' => ['employee', 'expert'],
         ],
     ];
 

--- a/backend/src/Infrastructure/Development/DevelopmentRequestSeeder.php
+++ b/backend/src/Infrastructure/Development/DevelopmentRequestSeeder.php
@@ -30,14 +30,6 @@ final class DevelopmentRequestSeeder
     /** @var list<string> */
     private const INITIATORS = ['employee', 'expert', 'expert2', 'security', 'admin'];
 
-    private const INITIATOR_DEPARTMENTS = [
-        'employee' => 'Тестовое подразделение',
-        'expert' => 'СГК',
-        'expert2' => 'СГК',
-        'security' => 'Служба безопасности',
-        'admin' => 'ИТ',
-    ];
-
     /** @var list<array{status: string, product: string, manufacturer: string, supplier: string, quantity: int, method: string, color: string}> */
     private const REQUESTS = [
         ['status' => 'registered', 'product' => 'Панель управления лифтом «Вектор»', 'manufacturer' => 'ООО «Учебные системы»', 'supplier' => 'ООО «Демо Комплект»', 'quantity' => 2, 'method' => 'Входной контроль комплектности и маркировки.', 'color' => 'white'],
@@ -70,6 +62,7 @@ final class DevelopmentRequestSeeder
     public function seed(): array
     {
         $users = $this->resolveUsers();
+        $initiatorDepartments = $this->resolveInitiatorDepartments($users);
         $oldKeys = $this->db->createCommand('SELECT storage_key FROM {{%request_document_versions}}')->queryColumn();
         $newKeys = [];
         $counts = ['requests' => 0, 'comments' => 0, 'documents' => 0];
@@ -82,7 +75,7 @@ final class DevelopmentRequestSeeder
                 $fixture['age'] = 8 + ($index % 83);
                 $initiator = self::INITIATORS[$index % count(self::INITIATORS)];
                 $initiatorId = $users[$initiator];
-                $requestId = $this->insertRequest($index, $fixture, $initiatorId, self::INITIATOR_DEPARTMENTS[$initiator]);
+                $requestId = $this->insertRequest($index, $fixture, $initiatorId, $initiatorDepartments[$initiatorId]);
                 ++$counts['requests'];
                 $counts['comments'] += $this->insertComments($requestId, $index, $fixture['age'], $initiatorId, $users);
                 $reportVersionId = null;
@@ -165,6 +158,37 @@ final class DevelopmentRequestSeeder
             $result[$name] = (int) $ids[$login];
         }
         return $result;
+    }
+
+    /**
+     * @param array<string, int> $users
+     * @return array<int, string>
+     */
+    private function resolveInitiatorDepartments(array $users): array
+    {
+        $params = [];
+        $placeholders = [];
+        foreach (self::INITIATORS as $index => $initiator) {
+            $placeholder = ':initiator' . $index;
+            $placeholders[] = $placeholder;
+            $params[$placeholder] = $users[$initiator];
+        }
+        $rows = $this->db->createCommand(
+            'SELECT id, NULLIF(TRIM(department), \'\') AS department FROM {{%users}} '
+            . 'WHERE id IN (' . implode(', ', $placeholders) . ')',
+            $params,
+        )->queryAll();
+        $departments = [];
+        foreach ($rows as $row) {
+            if ($row['department'] === null) {
+                throw new \RuntimeException("Development initiator '{$row['id']}' has no department.");
+            }
+            $departments[(int) $row['id']] = (string) $row['department'];
+        }
+        if (count($departments) !== count(self::INITIATORS)) {
+            throw new \RuntimeException('Cannot resolve all development initiator departments.');
+        }
+        return $departments;
     }
 
     private function clearRequestData(): void

--- a/backend/src/Infrastructure/Development/DevelopmentRequestSeeder.php
+++ b/backend/src/Infrastructure/Development/DevelopmentRequestSeeder.php
@@ -22,9 +22,21 @@ final class DevelopmentRequestSeeder
         'expert' => 'dev.expert',
         'expert2' => 'dev.expert2',
         'security' => 'dev.security',
+        'admin' => 'dev.admin',
     ];
 
     private const REQUEST_COUNT = 100;
+
+    /** @var list<string> */
+    private const INITIATORS = ['employee', 'expert', 'expert2', 'security', 'admin'];
+
+    private const INITIATOR_DEPARTMENTS = [
+        'employee' => 'Тестовое подразделение',
+        'expert' => 'СГК',
+        'expert2' => 'СГК',
+        'security' => 'Служба безопасности',
+        'admin' => 'ИТ',
+    ];
 
     /** @var list<array{status: string, product: string, manufacturer: string, supplier: string, quantity: int, method: string, color: string}> */
     private const REQUESTS = [
@@ -68,9 +80,11 @@ final class DevelopmentRequestSeeder
             for ($index = 0; $index < self::REQUEST_COUNT; ++$index) {
                 $fixture = self::REQUESTS[$index % count(self::REQUESTS)];
                 $fixture['age'] = 8 + ($index % 83);
-                $requestId = $this->insertRequest($index, $fixture, $users);
+                $initiator = self::INITIATORS[$index % count(self::INITIATORS)];
+                $initiatorId = $users[$initiator];
+                $requestId = $this->insertRequest($index, $fixture, $initiatorId, self::INITIATOR_DEPARTMENTS[$initiator]);
                 ++$counts['requests'];
-                $counts['comments'] += $this->insertComments($requestId, $index, $fixture['age'], $users);
+                $counts['comments'] += $this->insertComments($requestId, $index, $fixture['age'], $initiatorId, $users);
                 $reportVersionId = null;
 
                 $format = self::ATTACHMENT_FORMATS[($index * 5 + 3) % count(self::ATTACHMENT_FORMATS)];
@@ -79,7 +93,7 @@ final class DevelopmentRequestSeeder
                     'attachment',
                     sprintf('Сопроводительные материалы %03d.%s', $index + 1, $format['extension']),
                     $format['mime'],
-                    $users['employee'],
+                    $initiatorId,
                     $fixture['age'] - 1,
                 );
                 $newKeys[] = $version['key'];
@@ -163,14 +177,13 @@ final class DevelopmentRequestSeeder
 
     /**
      * @param array<string, mixed> $fixture
-     * @param array<string, int> $users
      */
-    private function insertRequest(int $index, array $fixture, array $users): int
+    private function insertRequest(int $index, array $fixture, int $initiatorId, string $department): int
     {
         $created = $this->time($fixture['age']);
         $this->db->createCommand()->insert('{{%requests}}', [
-            'number' => 1001 + $index, 'legacy_id' => null, 'initiator_id' => $users['employee'],
-            'department_name' => 'Тестовое подразделение', 'department_source' => 'current_profile',
+            'number' => 1001 + $index, 'legacy_id' => null, 'initiator_id' => $initiatorId,
+            'department_name' => $department, 'department_source' => 'current_profile',
             'status' => $fixture['status'], 'product_name' => sprintf('%s — демо-серия %03d', $fixture['product'], $index + 1),
             'manufacturer' => $fixture['manufacturer'], 'supplier' => $fixture['supplier'],
             'sample_quantity' => $fixture['quantity'], 'test_method' => $fixture['method'],
@@ -181,12 +194,12 @@ final class DevelopmentRequestSeeder
     }
 
     /** @param array<string, int> $users */
-    private function insertComments(int $requestId, int $index, int $age, array $users): int
+    private function insertComments(int $requestId, int $index, int $age, int $initiatorId, array $users): int
     {
         $thread = [
-            [$users['employee'], 'Демонстрационная заявка создана. Образцы готовы к передаче в ИЦ.'],
+            [$initiatorId, 'Демонстрационная заявка создана. Образцы готовы к передаче в ИЦ.'],
             [$users['executor'], 'Программа испытаний согласована. Отчёт будет загружен после завершения испытаний.'],
-            [$users['employee'], 'Передали комплект образцов и уточнили маркировку на упаковке. Просьба учесть, что один из образцов предназначен для разрушающего контроля, а остальные необходимо вернуть после завершения работ.'],
+            [$initiatorId, 'Передали комплект образцов и уточнили маркировку на упаковке. Просьба учесть, что один из образцов предназначен для разрушающего контроля, а остальные необходимо вернуть после завершения работ.'],
             [$users['executor2'], 'Информация принята. В журнале лаборатории зарезервировано оборудование, проверены условия проведения испытаний и доступность измерительного стенда. Если предварительные результаты выйдут за установленные программой пределы, добавим сюда таблицу измерений и отдельно согласуем повторный цикл.'],
         ];
         $comments = array_slice($thread, 0, 1 + ($index % count($thread)));

--- a/backend/tests/Integration/Development/DevelopmentRequestSeederTest.php
+++ b/backend/tests/Integration/Development/DevelopmentRequestSeederTest.php
@@ -6,6 +6,7 @@ namespace Tests\Integration\Development;
 
 use App\Infrastructure\Development\DevelopmentRequestSeeder;
 use App\Infrastructure\Document\DocumentStorage;
+use App\Infrastructure\Request\RequestQuery;
 use Tests\Integration\IntegrationTestCase;
 use yii\db\IntegrityException;
 
@@ -18,7 +19,7 @@ final class DevelopmentRequestSeederTest extends IntegrationTestCase
         parent::setUp();
         $this->storageRoot = sys_get_temp_dir() . '/ic-development-seed-test-' . bin2hex(random_bytes(8));
         mkdir($this->storageRoot, 0700, true);
-        foreach (['dev.user', 'dev.executor', 'dev.executor.naumov', 'dev.employee', 'dev.expert', 'dev.expert2', 'dev.security'] as $login) {
+        foreach (['dev.user', 'dev.executor', 'dev.executor.naumov', 'dev.employee', 'dev.expert', 'dev.expert2', 'dev.security', 'dev.admin'] as $login) {
             if ($this->scalar('SELECT id FROM {{%users}} WHERE ad_login = :login', [':login' => $login]) === false) {
                 $this->createUser($login, $login);
             }
@@ -64,6 +65,52 @@ final class DevelopmentRequestSeederTest extends IntegrationTestCase
         self::assertSame(
             ['completed', 'in_progress', 'opinion_preparation', 'registered', 'rejected', 'security_review', 'suspended', 'withdrawn'],
             $this->db()->createCommand('SELECT DISTINCT status FROM {{%requests}} ORDER BY status')->queryColumn(),
+        );
+        $initiatorIds = array_map(
+            'intval',
+            $this->db()->createCommand('SELECT DISTINCT initiator_id FROM {{%requests}} ORDER BY initiator_id')->queryColumn(),
+        );
+        self::assertCount(5, $initiatorIds);
+        foreach ($initiatorIds as $initiatorId) {
+            $mine = (new RequestQuery($this->db()))->findPage($initiatorId, 1, 100, 'mine', null, '', 'desc');
+            $statuses = array_values(array_unique(array_column($mine['items'], 'status')));
+            sort($statuses);
+            self::assertSame(
+                ['completed', 'in_progress', 'opinion_preparation', 'registered', 'rejected', 'security_review', 'suspended', 'withdrawn'],
+                $statuses,
+            );
+        }
+        self::assertSame(
+            0,
+            (int) $this->scalar(
+                'SELECT COUNT(DISTINCT r.initiator_id) FROM {{%requests}} r '
+                . 'JOIN {{%user_roles}} ur ON ur.user_id = r.initiator_id '
+                . 'JOIN {{%roles}} role ON role.id = ur.role_id '
+                . "WHERE role.code IN ('ic_executor', 'ic_manager', 'laboratory_manager')",
+            ),
+        );
+        self::assertSame(
+            0,
+            (int) $this->scalar(
+                'SELECT COUNT(*) FROM {{%requests}} r JOIN {{%users}} u ON u.id = r.initiator_id '
+                . "WHERE r.department_name <> u.department OR r.department_source <> 'current_profile'",
+            ),
+        );
+        self::assertSame(
+            0,
+            (int) $this->scalar(
+                'SELECT COUNT(*) FROM {{%requests}} r JOIN {{%request_documents}} d ON d.request_id = r.id '
+                . 'JOIN {{%request_document_versions}} v ON v.document_id = d.id '
+                . "WHERE d.document_type = 'attachment' AND v.uploaded_by <> r.initiator_id",
+            ),
+        );
+        self::assertSame(
+            0,
+            (int) $this->scalar(
+                'SELECT COUNT(*) FROM {{%requests}} r JOIN {{%request_comments}} c ON c.request_id = r.id '
+                . 'AND c.id = (SELECT MIN(first_comment.id) FROM {{%request_comments}} first_comment '
+                . 'WHERE first_comment.request_id = r.id) WHERE c.author_id <> r.initiator_id',
+            ),
         );
         self::assertSame(0, (int) $this->scalar('SELECT COUNT(*) FROM {{%requests}} WHERE legacy_id IS NOT NULL'));
         self::assertSame(['approve', 'return'], $this->db()->createCommand('SELECT DISTINCT decision FROM {{%security_checks}} ORDER BY decision')->queryColumn());

--- a/backend/tests/Integration/Development/DevelopmentRequestSeederTest.php
+++ b/backend/tests/Integration/Development/DevelopmentRequestSeederTest.php
@@ -19,9 +19,26 @@ final class DevelopmentRequestSeederTest extends IntegrationTestCase
         parent::setUp();
         $this->storageRoot = sys_get_temp_dir() . '/ic-development-seed-test-' . bin2hex(random_bytes(8));
         mkdir($this->storageRoot, 0700, true);
-        foreach (['dev.user', 'dev.executor', 'dev.executor.naumov', 'dev.employee', 'dev.expert', 'dev.expert2', 'dev.security', 'dev.admin'] as $login) {
-            if ($this->scalar('SELECT id FROM {{%users}} WHERE ad_login = :login', [':login' => $login]) === false) {
-                $this->createUser($login, $login);
+        $departments = [
+            'dev.user' => 'Испытательный центр',
+            'dev.executor' => 'Испытательный центр',
+            'dev.executor.naumov' => 'Испытательный центр',
+            'dev.employee' => 'Тестовое подразделение',
+            'dev.expert' => 'СГК',
+            'dev.expert2' => 'СГК',
+            'dev.security' => 'Служба безопасности',
+            'dev.admin' => 'ИТ',
+        ];
+        foreach ($departments as $login => $department) {
+            $userId = $this->scalar('SELECT id FROM {{%users}} WHERE ad_login = :login', [':login' => $login]);
+            if ($userId === false) {
+                $this->createUser($login, $login, department: $department);
+            } else {
+                $this->db()->createCommand()->update(
+                    '{{%users}}',
+                    ['department' => $department],
+                    ['id' => (int) $userId],
+                )->execute();
             }
         }
     }


### PR DESCRIPTION
Closes #214

## Цель

Сделать набор из 100 demo-заявок пригодным для проверки вкладки «Мои заявки»: распределить авторство между допустимыми инициаторами и гарантировать каждому из них заявки на всех стадиях.

## Что изменено

- заявки циклически распределены между обычным сотрудником, двумя экспертами СГК, сотрудником СБ и администратором;
- сотрудники с ролями `ic_executor`, `ic_manager` и `laboratory_manager` не используются как инициаторы согласно REQ-001;
- сочетание циклов из пяти авторов и восьми статусов гарантирует каждому автору все стадии;
- первая реплика обсуждения и сопроводительный файл создаются от имени фактического инициатора;
- снимок подразделения соответствует профилю инициатора;
- подразделение обоих development-экспертов исправлено на «СГК».

## Тесты

Интеграционный тест теперь проверяет:

- пять разных инициаторов;
- все восемь статусов во вкладке «Мои заявки» каждого инициатора;
- отсутствие запрещённых ролей ИЦ у авторов;
- соответствие подразделения профилю;
- авторство первой реплики и сопроводительного документа.

## Проверка

- pre-push `make check` — успешно:
  - OpenAPI validation;
  - ESLint и npm audit;
  - Vitest: 174/174;
  - Composer validate, lint, PHPStan и audit;
  - PHPUnit: 287/287, 541 assertion;
  - repository contracts и Markdown lint;
- `git diff --check` — успешно.

Focused integration deployment локально не дошёл до PHPUnit из-за нестабильности общего Docker-окружения: до запуска теста завершались backend/AD и healthcheck MariaDB/Mailpit. Контейнеры и test volumes после попыток очищены.

## Риски и откат

Риск низкий: изменение ограничено development seed и профилями development-пользователей. Миграций и production workflow нет. Для отката вернуть commit и повторно заполнить demo-реестр.