### PR TITLE
Исправить GitLab CI и обновить PHP_CodeSniffer

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,11 +1,26 @@
 stages: [test]
 
+default:
+  tags: [runner-test]
+
 workflow:
   rules:
     - if: '$CI_PIPELINE_SOURCE == "merge_request_event"'
     - if: '$CI_COMMIT_BRANCH == $CI_DEFAULT_BRANCH'
 
+.docker-bookworm:
+  before_script:
+    - apt-get update
+    - apt-get install -y --no-install-recommends ca-certificates curl make python3-pip sudo
+    - install -m 0755 -d /etc/apt/keyrings
+    - curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
+    - chmod a+r /etc/apt/keyrings/docker.asc
+    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list
+    - apt-get update
+    - apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin
+
 check:
+  extends: .docker-bookworm
   stage: test
   image: node:22.23.0-bookworm
   services:
@@ -14,13 +29,12 @@ check:
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends curl docker.io docker-compose-v2 make python3-pip sudo
+  script:
     - sh scripts/install-ci-linters.sh
-  script: [make check]
+    - make check
 
 coverage:
+  extends: .docker-bookworm
   stage: test
   image: node:22.23.0-bookworm
   services:
@@ -29,9 +43,6 @@ coverage:
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
-  before_script:
-    - apt-get update
-    - apt-get install -y --no-install-recommends docker.io make python3
   script: [make coverage]
 
 e2e:

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -15,7 +15,7 @@ workflow:
     - install -m 0755 -d /etc/apt/keyrings
     - curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc
     - chmod a+r /etc/apt/keyrings/docker.asc
-    - echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian $(. /etc/os-release && echo \"$VERSION_CODENAME\") stable" > /etc/apt/sources.list.d/docker.list
+    - . /etc/os-release && echo "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/debian ${VERSION_CODENAME} stable" > /etc/apt/sources.list.d/docker.list
     - apt-get update
     - apt-get install -y --no-install-recommends docker-ce-cli docker-compose-plugin
 

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -3553,19 +3553,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
                 "shasum": ""
             },
             "require": {
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
@@ -3573,6 +3574,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
             },
             "bin": [
                 "bin/phpcbf",
@@ -3628,7 +3633,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-10T16:43:36+00:00"
+            "time": "2026-08-06T02:45:27+00:00"
         },
         {
             "name": "staabm/side-effects-detector",
@@ -3748,5 +3753,5 @@
         "ext-zip": "*"
     },
     "platform-dev": {},
-    "plugin-api-version": "2.9.0"
+    "plugin-api-version": "2.6.0"
 }


### PR DESCRIPTION
## Цель

- устанавливать Docker CLI и Compose plugin из официального репозитория Docker в GitLab CI на Debian Bookworm;
- обновить PHP_CodeSniffer с 4.0.1 до 4.0.4, устранив CVE-2026-67434;
- сохранить обязательную проверку зависимостей без подавления `composer audit`.

## Связанные правила

Изменение не затрагивает бизнес-правила и пользовательское поведение.

## Риски

- изменение затрагивает CI/CD и установку инструментов внутри CI-контейнеров;
- runner с тегом `runner-test` должен иметь доступ к Docker daemon и внешним Debian/Docker/PECL-репозиториям;
- сборка coverage по-прежнему зависит от доступности PECL при установке Xdebug.

## Проверка

Выполнен `make check`:

- OpenAPI validation — успешно;
- ESLint и frontend build — успешно;
- Vitest: 187 тестов — успешно;
- PHPCS и PHPStan — успешно;
- `composer audit`: уязвимостей не найдено;
- PHPUnit: 287 тестов, 541 assertion — успешно;
- repository contracts и Markdown lint — успешно.

## Откат

Откатить merge-коммит PR. Изменений данных, схемы БД и runtime-конфигурации приложения нет.

## Review

Изменение CI/CD и безопасности требует как минимум одного reviewer согласно инженерному стандарту.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved automated build and verification workflows for greater consistency.
  * Standardized the environment used for checks and coverage reporting.
  * Streamlined installation of required validation tools before checks run.
  * Updated container tooling support for more reliable build and test execution.
  * Improved workflow configuration so validation jobs run with consistent settings across environments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->