### PR TITLE
Изолировать stateful E2E от параллельного запуска

### DIFF
--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -3553,19 +3553,20 @@
         },
         {
             "name": "squizlabs/php_codesniffer",
-            "version": "4.0.1",
+            "version": "4.0.4",
             "source": {
                 "type": "git",
                 "url": "https://github.com/PHPCSStandards/PHP_CodeSniffer.git",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5"
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/0525c73950de35ded110cffafb9892946d7771b5",
-                "reference": "0525c73950de35ded110cffafb9892946d7771b5",
+                "url": "https://api.github.com/repos/PHPCSStandards/PHP_CodeSniffer/zipball/bbdc3d0532623e21838b7041a4364383a8126f96",
+                "reference": "bbdc3d0532623e21838b7041a4364383a8126f96",
                 "shasum": ""
             },
             "require": {
+                "ext-libxml": "*",
                 "ext-simplexml": "*",
                 "ext-tokenizer": "*",
                 "ext-xmlwriter": "*",
@@ -3573,6 +3574,10 @@
             },
             "require-dev": {
                 "phpunit/phpunit": "^8.4.0 || ^9.3.4 || ^10.5.32 || 11.3.3 - 11.5.28 || ^11.5.31"
+            },
+            "suggest": {
+                "ext-iconv": "For accurate character length calculation when the checked files contain multi-byte characters.",
+                "ext-pcntl": "For parallel processing support via the --parallel CLI option."
             },
             "bin": [
                 "bin/phpcbf",
@@ -3628,7 +3633,7 @@
                     "type": "thanks_dev"
                 }
             ],
-            "time": "2025-11-10T16:43:36+00:00"
+            "time": "2026-08-06T02:45:27+00:00"
         },
         {
             "name": "staabm/side-effects-detector",

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -62,6 +62,15 @@ health checks, backend Integration, повторный reset, Playwright и за
 При любом исходе teardown удаляет containers, network и test volumes, но
 сохраняет images, dependency caches и Playwright diagnostics.
 
+Playwright сначала запускает обычные сценарии в параллельном проекте
+`chromium`. После их успешного завершения зависимый проект
+`stateful-chromium` одним worker последовательно выполняет
+`idempotency.e2e.js` и `notifications.e2e.js`, чтобы они не конкурировали за
+общее состояние тестовой БД. Если `chromium` падает, зависимый проект
+пропускается. Полный порядок воспроизводится командой `make e2e`; при уже
+поднятом test-окружении отдельный проект можно запустить из `frontend` командой
+`npx playwright test --project=stateful-chromium --no-deps`.
+
 Runtime contracts проверяют реальный LDAP bind и группы, восстановление LDAP,
 SMTP failure/recovery, reconnect scheduler после рестарта MariaDB и SIGTERM.
 Playwright artifacts находятся в `frontend/playwright-report`.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -68,8 +68,16 @@ Playwright сначала запускает обычные сценарии в 
 `idempotency.e2e.js` и `notifications.e2e.js`, чтобы они не конкурировали за
 общее состояние тестовой БД. Если `chromium` падает, зависимый проект
 пропускается. Полный порядок воспроизводится командой `make e2e`; при уже
-поднятом test-окружении отдельный проект можно запустить из `frontend` командой
-`npx playwright test --project=stateful-chromium --no-deps`.
+поднятом test-окружении отдельный проект запускается из `frontend` так:
+
+```sh
+E2E_BASE_URL=http://localhost:18080 \
+MAILPIT_BASE_URL=http://localhost:18026 \
+npx playwright test --project=stateful-chromium --no-deps
+```
+
+При переопределении `FRONTEND_PORT` или `MAILPIT_PORT` URL нужно изменить
+соответственно.
 
 Runtime contracts проверяют реальный LDAP bind и группы, восстановление LDAP,
 SMTP failure/recovery, reconnect scheduler после рестарта MariaDB и SIGTERM.

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -71,6 +71,8 @@ Playwright сначала запускает обычные сценарии в 
 поднятом test-окружении отдельный проект запускается из `frontend` так:
 
 ```sh
+npm ci --no-audit --no-fund
+npx playwright install chromium
 E2E_BASE_URL=http://localhost:18080 \
 MAILPIT_BASE_URL=http://localhost:18026 \
 npx playwright test --project=stateful-chromium --no-deps

--- a/frontend/e2e/critical-flow.e2e.js
+++ b/frontend/e2e/critical-flow.e2e.js
@@ -145,6 +145,7 @@ test('заявка перемещается между персональным�
     await expectOk(await manager.post(`/api/v1/requests/${requestId}/executor`, {
       data: { executorId: 2, lockVersion: 1 },
     }))
+    await page.reload()
     await page.getByTitle('На главную').click()
     await expect(page.getByRole('row').filter({ hasText: marker })).toHaveCount(0)
 
@@ -156,6 +157,7 @@ test('заявка перемещается между персональным�
     await expectOk(await executor.post(`/api/v1/requests/${requestId}/start`, {
       data: { lockVersion: 2 },
     }))
+    await executorPage.reload()
     await executorPage.getByRole('button', { name: /Загрузить отчёт/ }).click()
     await expect(executorPage.getByRole('row').filter({ hasText: marker })).toBeVisible()
     await expectOk(await executor.post(`/api/v1/requests/${requestId}/report`, {

--- a/frontend/e2e/critical-flow.e2e.js
+++ b/frontend/e2e/critical-flow.e2e.js
@@ -146,7 +146,10 @@ test('заявка перемещается между персональным�
       data: { executorId: 2, lockVersion: 1 },
     }))
     await page.reload()
-    await page.getByTitle('На главную').click()
+    await Promise.all([
+      page.waitForResponse(response => response.url().includes('/api/v1/requests/dashboard') && response.ok()),
+      page.getByTitle('На главную').click(),
+    ])
     await expect(page.getByRole('row').filter({ hasText: marker })).toHaveCount(0)
 
     const executorPage = await context.newPage()

--- a/frontend/e2e/critical-flow.e2e.js
+++ b/frontend/e2e/critical-flow.e2e.js
@@ -139,18 +139,25 @@ test('заявка перемещается между персональным�
     await expect(dashboardHelpDialog).toContainText('Заявки, требующие внимания')
     await page.getByRole('button', { name: 'Закрыть справку' }).click()
     await expect(dashboardHelpDialog).toBeHidden()
-    await page.getByRole('button', { name: /Назначить исполнителя/ }).click()
+    const managerQueue = page.getByRole('button', { name: /Назначить исполнителя/ })
+    const managerCountBefore = Number(await managerQueue.locator('.attention-count').innerText())
+    await managerQueue.click()
     await page.getByRole('row').filter({ hasText: marker }).click()
 
     await expectOk(await manager.post(`/api/v1/requests/${requestId}/executor`, {
       data: { executorId: 2, lockVersion: 1 },
     }))
-    await page.reload()
     await Promise.all([
       page.waitForResponse(response => response.url().includes('/api/v1/requests/dashboard') && response.ok()),
       page.getByTitle('На главную').click(),
     ])
-    await expect(page.getByRole('row').filter({ hasText: marker })).toHaveCount(0)
+    if (managerCountBefore === 1) {
+      await expect(managerQueue).toHaveCount(0)
+    } else {
+      await expect(managerQueue.locator('.attention-count')).toHaveText(String(managerCountBefore - 1))
+      await managerQueue.click()
+      await expect(page.getByRole('row').filter({ hasText: marker })).toHaveCount(0)
+    }
 
     const executorPage = await context.newPage()
     await useTestIdentity(executorPage, 2)

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -12,5 +12,18 @@ export default defineConfig({
     screenshot: 'only-on-failure',
     video: 'retain-on-failure',
   },
-  projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+  projects: [
+    {
+      name: 'chromium',
+      testIgnore: ['**/idempotency.e2e.js', '**/notifications.e2e.js'],
+      use: { ...devices['Desktop Chrome'] },
+    },
+    {
+      name: 'stateful-chromium',
+      testMatch: ['**/idempotency.e2e.js', '**/notifications.e2e.js'],
+      dependencies: ['chromium'],
+      workers: 1,
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
 })

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -1,5 +1,7 @@
 import { defineConfig, devices } from '@playwright/test'
 
+const statefulTests = ['**/idempotency.e2e.js', '**/notifications.e2e.js']
+
 export default defineConfig({
   testDir: './e2e',
   testMatch: '**/*.e2e.js',
@@ -15,12 +17,12 @@ export default defineConfig({
   projects: [
     {
       name: 'chromium',
-      testIgnore: ['**/idempotency.e2e.js', '**/notifications.e2e.js'],
+      testIgnore: statefulTests,
       use: { ...devices['Desktop Chrome'] },
     },
     {
       name: 'stateful-chromium',
-      testMatch: ['**/idempotency.e2e.js', '**/notifications.e2e.js'],
+      testMatch: statefulTests,
       dependencies: ['chromium'],
       workers: 1,
       use: { ...devices['Desktop Chrome'] },


### PR DESCRIPTION
## Цель

Устранить конкуренцию stateful E2E за общую тестовую БД, из-за которой `notifications.e2e.js` периодически получал HTTP 500 при параллельном создании заявок.

## Что изменено

- обычные E2E остаются в параллельном проекте `chromium`;
- `idempotency.e2e.js` и `notifications.e2e.js` вынесены в зависимый проект `stateful-chromium`;
- stateful-сценарии выполняются после основного проекта последовательно одним worker;
- список stateful-файлов хранится в одной константе;
- порядок запуска и skip-семантика описаны в стратегии тестирования;
- проверка персональной очереди синхронизирована с загрузкой dashboard и проверяет счётчик очереди, а не общий реестр;
- `squizlabs/php_codesniffer` обновлён с 4.0.1 до 4.0.4, потому что required check этого PR начал падать на high-severity CVE-2026-67434 (`GHSA-hmqg-cxww-wqhq`, исправлено в >=4.0.2).

## Связанные правила и задачи

Closes #222

## Проверка

- `make check` — успешно, включая `composer audit`: advisories отсутствуют;
- `make e2e` — 16/16 Playwright и runtime-проверки успешно;
- `npm --prefix frontend run lint` — успешно;
- `git diff --check` — успешно.

## Риски и откат

Изменяется порядок E2E, синхронизация одного E2E-сценария и lock-запись dev-инструмента PHPCS. Обновление PHPCS необходимо для прохождения обязательного security audit; production-зависимости и данные не затрагиваются.

## Метки

- [x] назначена ровно одна метка `type:*`;
- [x] назначены все применимые метки `area:*`;
- [x] назначена ровно одна метка `risk:*`;
- [x] `dependencies` применима только к dev-инструменту PHPCS;
- [x] `breaking-change` не применима.

## Готовность

- [ ] тесты и обязательный pipeline проходят;
- [ ] Qodo завершил проверку текущего head-коммита и все review threads закрыты;
- [x] документация и пользовательские инструкции актуализированы;
- [x] миграции не изменялись;
- [x] секреты и персональные данные не попали в код и логи.
