### PR TITLE
Исключить локальные deployment-файлы из production-образа

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 backend/vendor
 backend/runtime
 backend/build
+# Production has no deployment fragments; dev/test mount them through Compose.
 backend/deployment
 frontend/coverage
 frontend/playwright-report

--- a/.dockerignore
+++ b/.dockerignore
@@ -5,6 +5,7 @@
 backend/vendor
 backend/runtime
 backend/build
+backend/deployment
 frontend/coverage
 frontend/playwright-report
 frontend/test-results

--- a/scripts/check-deployment-contracts.sh
+++ b/scripts/check-deployment-contracts.sh
@@ -140,6 +140,7 @@ set -e
 
 grep -q 'MAILPIT_BASE_URL must be provided' frontend/e2e/notifications.e2e.js
 grep -Fq 'COPY frontend/package*.json frontend/.npmrc ./' docker/frontend.Dockerfile
+grep -Fxq 'backend/deployment' .dockerignore
 
 # Production и development images должны содержать проверенный контракт и
 # локальные Swagger UI assets; каждый stage проверяется независимо.


### PR DESCRIPTION
## Причина

Локальные пустые файлы `backend/deployment/web.php` и `backend/deployment/console.php` попадали в production Docker image. Yii воспринимал результат `require` как число, печатал warning до отправки заголовков и возвращал ложный HTTP 200 вместо JSON-ответа авторизации.

## Изменение

- каталог `backend/deployment` исключён из Docker build context;
- deployment contract закрепляет это правило регрессионной проверкой.

## Проверка

- `make check` — успешно;
- production backend image не содержит deployment fragments;
- `auth/me` возвращает JSON и CSRF-токен;
- отклонённый `auth/login` возвращает корректный HTTP 400 JSON.

## Риск и откат

Риск низкий: development/test fragments по-прежнему подключаются Compose bind mounts. Откат — revert коммита.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated container build exclusions to omit deployment-specific files.
  * Enhanced deployment validation to confirm the exclusion is configured correctly.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->