### PR TITLE
CI: избежать конфликта Unix-сокета Docker-in-Docker

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,7 +25,7 @@ check:
   image: node:22.23.0-bookworm
   services:
     - name: docker:29.0.0-dind
-      command: ["--tls=false"]
+      command: ["dockerd", "--tls=false", "--host=tcp://0.0.0.0:2375"]
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
@@ -39,7 +39,7 @@ coverage:
   image: node:22.23.0-bookworm
   services:
     - name: docker:29.0.0-dind
-      command: ["--tls=false"]
+      command: ["dockerd", "--tls=false", "--host=tcp://0.0.0.0:2375"]
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""
@@ -50,7 +50,7 @@ e2e:
   image: mcr.microsoft.com/playwright:v1.62.0-noble
   services:
     - name: docker:29.0.0-dind
-      command: ["--tls=false"]
+      command: ["dockerd", "--tls=false", "--host=tcp://0.0.0.0:2375"]
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""


### PR DESCRIPTION
## Что изменено

- GitLab DinD-сервисы запускают `dockerd` явно.
- Docker daemon слушает только TCP `2375` и не пытается создать занятый runner-ом `/var/run/docker.sock`.
- Исправление применяется к `check`, `coverage` и `e2e`.

## Проверка

- DinD успешно запущен с занятым `/var/run/docker.sock` и доступен на TCP `2375`.
- `make check` прошёл локально: 233 frontend-теста и 287 backend-тестов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated containerized check, coverage, and end-to-end test jobs to improve Docker service connectivity.
  * No user-facing product changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->