### PR TITLE
Исправить детали интерфейса реестра

### DIFF
--- a/backend/src/Domain/Request/AttentionQueue.php
+++ b/backend/src/Domain/Request/AttentionQueue.php
@@ -29,7 +29,7 @@ enum AttentionQueue: string
     {
         return match ($this) {
             self::AssignExecutor => 'Назначьте ответственного за проведение испытаний.',
-            self::StartOrResumeWork => 'Начните работу по зарегистрированным заявкам или возобновите приостановленные.',
+            self::StartOrResumeWork => 'Начните или возобновите работу по заявке.',
             self::UploadReport => 'Загрузите отчёт о результатах испытаний в формате PDF.',
             self::ClaimExpert => 'Возьмите заявку в работу для подготовки заключения.',
             self::PublishOpinion => 'Подготовьте и опубликуйте экспертное заключение.',

--- a/backend/tests/Unit/Domain/Request/AttentionQueueTest.php
+++ b/backend/tests/Unit/Domain/Request/AttentionQueueTest.php
@@ -15,7 +15,7 @@ final class AttentionQueueTest extends TestCase
         self::assertSame(
             [
                 'assign_executor' => ['Назначить исполнителя', 'Назначьте ответственного за проведение испытаний.', [Role::IcManager, Role::LaboratoryManager]],
-                'start_or_resume_work' => ['Начать или возобновить работы', 'Начните работу по зарегистрированным заявкам или возобновите приостановленные.', [Role::IcExecutor, Role::IcManager, Role::LaboratoryManager]],
+                'start_or_resume_work' => ['Начать или возобновить работы', 'Начните или возобновите работу по заявке.', [Role::IcExecutor, Role::IcManager, Role::LaboratoryManager]],
                 'upload_report' => ['Загрузить отчёт', 'Загрузите отчёт о результатах испытаний в формате PDF.', [Role::IcExecutor, Role::IcManager, Role::LaboratoryManager]],
                 'claim_expert' => ['Взять заявку на экспертизу', 'Возьмите заявку в работу для подготовки заключения.', [Role::Expert]],
                 'publish_opinion' => ['Подготовить заключение', 'Подготовьте и опубликуйте экспертное заключение.', [Role::Expert]],

--- a/frontend/src/components/RequestRegistry.vue
+++ b/frontend/src/components/RequestRegistry.vue
@@ -681,7 +681,7 @@ onBeforeUnmount(() => {
           :disabled="paged.page <= 1" aria-label="Предыдущая страница" @click="goToPage(paged.page - 1)"
         ><AppIcon name="chevron-left" :size="16" /></button><button
           v-for="page in pageNumbers" :key="page" :class="{ current: page === paged.page }" :aria-label="`Страница ${page}`" :aria-current="page === paged.page ? 'page' : undefined" @click="goToPage(page)"
-        >{{ page }}</button><button
+        ><span class="pagination-page-number">{{ page }}</span></button><button
           :disabled="paged.page >= paged.pageCount" aria-label="Следующая страница" @click="goToPage(paged.page + 1)"
         ><AppIcon name="chevron-right" :size="16" /></button></span>
         <span class="pagination-range">{{ (paged.page - 1) * pageSize + 1 }}–{{

--- a/frontend/src/styles.css
+++ b/frontend/src/styles.css
@@ -152,6 +152,9 @@
 @media (max-width:770px){.registry-head{padding:12px 14px 0}.registry .tabs{gap:14px;overflow-x:auto}.registry .tab-label{white-space:nowrap}.registry .toolbar{padding:10px 14px}.registry .search{width:100%;min-width:100%}.registry .status-filter,.registry .status-filter select{width:100%}}
 @media (max-width:770px){.attention-grid{grid-template-columns:1fr}.attention-dashboard{padding:12px}}
 
+/* Security marks use the status symbol alone; color carries the decision state. */
+.security-mark-icon:is(.security-mark--approve,.security-mark--return,.security-mark--pending){border-radius:0;background:transparent}
+
 /* Shared screen entrance keeps registry/details swaps calm without unmounting registry state. */
 @keyframes screen-enter{from{opacity:.35}to{opacity:1}}
 .screen-panel--active{animation:screen-enter .22s ease-out both}
@@ -354,3 +357,4 @@
 .registry th:last-child{width:5%;white-space:nowrap;overflow-wrap:normal}
 .registry .pagination-pages{display:inline-flex;align-items:center;gap:6px;line-height:0}
 .registry .pagination-pages button{flex:0 0 34px;margin-left:0;vertical-align:middle}
+.registry .pagination-page-number{width:100%;height:100%;display:grid;place-items:center;line-height:1}


### PR DESCRIPTION
## Цель

Устранить визуальные несоответствия в реестре заявок: разную высоту персональных задач, лишнюю цветную подложку отметки СБ и неточное центрирование номеров страниц.

## Что изменено

- сокращено описание очереди «Начать или возобновить работы» без изменения её правил и состава;
- отметка СБ отображается только символом с сохранением смыслового цвета и доступной подписи;
- номера страниц занимают всю область круглой кнопки и центрируются по обеим осям.

## Связанные правила и задачи

- DASH-003 — состав очереди «Начать или возобновить работы» не меняется;
- SEC-002 и SEC-003 — смысл и цвет состояний отметки СБ сохраняются;
- отдельной задачи нет.

## Проверка

- make check — успешно;
- frontend: 240 Vitest-тестов, ESLint, npm audit и production build — успешно;
- backend: 349 PHPUnit-тестов, 654 assertions, PHPStan, Composer audit и repository lint — успешно;
- вручную проверена вычисленная геометрия номера страницы на development-стенде: область номера совпадает с областью кнопки.

## Риски и откат

Риск низкий: изменения локальны для текстового описания и представления элементов реестра, workflow и API не меняются. Откат — revert единственного коммита PR.

## Метки

- [x] назначена ровно одна метка type:*;
- [x] назначены все применимые метки area:*;
- [x] назначена ровно одна метка risk:*;
- [x] dependencies и breaking-change не требуются.

## Готовность

- [ ] тесты и обязательный pipeline проходят;
- [ ] Qodo завершил проверку текущего head-коммита и все review threads закрыты;
- [x] документация и пользовательские инструкции не требуют изменения: сценарии и правила не менялись;
- [x] миграция не требуется;
- [x] секреты и персональные данные не добавлены.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Updated the attention-queue message for starting or resuming work on a request.
  * Improved pagination page-number alignment and line-height consistency.
  * Simplified security status indicators to display clear state colors without additional background styling.

* **Tests**
  * Updated coverage to reflect the revised attention-queue message.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->