### PR TITLE
test(admin): стабилизировать проверку таймаута LDAP

### DIFF
--- a/backend/tests/Integration/Http/BreakGlassLoginTest.php
+++ b/backend/tests/Integration/Http/BreakGlassLoginTest.php
@@ -159,12 +159,15 @@ PHP;
             putenv('LDAP_USE_TLS=true');
             $this->createApplication(self::LOGIN, self::PASSWORD);
             (new AuthController('auth', Yii::$app))->actionLogin();
-            $startedAt = microtime(true);
+            $startedAt = hrtime(true);
 
             $overview = (new AdminController('admin', Yii::$app))->actionSystemOverview();
 
             self::assertSame('error', $overview['services']['ldap']['status']);
-            self::assertLessThan(8.0, microtime(true) - $startedAt);
+            $elapsedSeconds = (hrtime(true) - $startedAt) / 1_000_000_000;
+            // The alarm fires after 6 seconds and the unbounded fixture sleeps for 15.
+            // Keep enough runner scheduling margin while still detecting a missing timeout.
+            self::assertLessThan(12.0, $elapsedSeconds);
         } finally {
             fclose($server);
             foreach ($pipes as $pipe) {


### PR DESCRIPTION
## Цель

Устранить нестабильное падение E2E-проверки таймаута LDAP, добавленной в #250, и сохранить одинаковое исправление в GitHub и корпоративном GitLab.

## Изменения

- измерение длительности переведено с wall clock на монотонный `hrtime`;
- предел проверки увеличен с 8 до 12 секунд: штатный alarm срабатывает через 6 секунд, а fixture без ограничения удерживает соединение 15 секунд.

Регрессия отсутствующего таймаута по-прежнему обнаруживается, но задержка загруженного runner в несколько миллисекунд больше не приводит к случайному падению.

## Проверка

- `make check` — успешно;
- `make e2e` — успешно локально на эквивалентном изменении;
- GitLab pipeline #593 — успешно: все jobs, включая E2E.

## Риск и откат

Риск низкий: изменён только временной контракт integration-теста. Откат — revert единственного commit.