### PR TITLE
ci: integrate SonarQube Cloud analysis

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
       contents: read
       pull-requests: read
     steps:
-      - uses: actions/checkout@v7
+      - uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1  # v7.0.1
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -41,6 +41,14 @@ jobs:
           cache: npm
           cache-dependency-path: frontend/package-lock.json
       - run: make coverage
+      - uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a  # v7
+        with:
+          name: sonar-coverage
+          path: |
+            backend/build/coverage/clover.xml
+            frontend/coverage/lcov.info
+          if-no-files-found: error
+          retention-days: 1
 
   e2e:
     runs-on: ubuntu-latest
@@ -84,3 +92,26 @@ jobs:
       - uses: gitleaks/gitleaks-action@v3
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  sonar:
+    needs: [check, coverage, e2e, analyze, secrets]
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c  # v8
+        with:
+          name: sonar-coverage
+      - name: Normalize container paths in PHP coverage
+        run: |
+          grep -q 'name="/app/' backend/build/coverage/clover.xml
+          sed -i 's#name="/app/#name="backend/#g' backend/build/coverage/clover.xml
+          ! grep -q 'name="/app/' backend/build/coverage/clover.xml
+      - uses: SonarSource/sonarqube-scan-action@22918119ff8e1ca75a623e15c8296b6ea4fbe28f  # v8.2.1
+        env:
+          SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -9,6 +9,7 @@ GitHub Actions и GitLab CI используют Makefile как источни�
 | Docker test deployment suite | `e2e` | `e2e` | `make e2e` |
 | Semgrep | `analyze` | `analyze` | `semgrep scan` |
 | secrets | `secrets` | `secrets` | Gitleaks |
+| SonarQube Cloud | `sonar` | — | импорт существующих coverage reports и анализ new code |
 
 E2E job обязателен и не использует `allow_failure`. Он поднимает один test
 deployment, выполняет Integration, Playwright, LDAP/SMTP contracts, MariaDB
@@ -29,3 +30,23 @@ OpenAPI отдельно запускается командой `make openapi-v
 `make check`. Проверка работает по lock-файлу без сетевых запросов: валидирует
 обязательные поля OpenAPI, разрешает `$ref` и проверяет инфраструктурный срез,
 security/idempotency и локальную конфигурацию Swagger UI.
+
+## SonarQube Cloud
+
+GitHub job `sonar` запускается только после deterministic jobs и анализирует
+`main` и pull request через проект `Antropophag_ic`. Анализ выполняется в CI;
+Automatic Analysis для проекта должен быть выключен, поскольку эти режимы нельзя
+использовать одновременно. Токен хранится только в GitHub Secret `SONAR_TOKEN`.
+
+Sonar импортирует Clover, уже создаваемый backend coverage job, и LCOV из того же
+Vitest coverage run. Миграционная baseline зафиксирована на последнем проверенном
+анализе `main`; для pull request new code всегда является diff относительно target
+branch. Historical findings остаются baseline debt и не должны сами по себе
+блокировать PR. Подробности issue и data-flow доступны по ссылке из GitHub check
+в SonarQube Cloud.
+
+Sonar дополняет, но не заменяет PHPStan, PHPCS, ESLint, Semgrep, Gitleaks,
+dependency audit, тесты, historical guards, Codex review, Qodo и CodeRabbit.
+Статический анализ не подтверждает бизнес-контракты, runtime concurrency,
+устаревшие async responses, browser lifecycle, viewport/zoom и reduced-motion;
+эти риски остаются за тестами, guards и semantic review.

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -7,7 +7,7 @@ export default defineConfig({
     coverage: {
       provider: 'v8',
       include: ['src/api.js', 'src/applicationDraftForm.js', 'src/applicationDraftStorage.js', 'src/bootstrap.js', 'src/confirmDialog.js', 'src/latestRequestGuard.js', 'src/registry.js', 'src/requestRegistryLoadLifecycle.js', 'dev/dev-tools.js', 'dev/review-guide.js'],
-      reporter: ['text', 'json-summary'],
+      reporter: ['text', 'json-summary', 'lcov'],
       thresholds: {
         lines: 80,
         functions: 80,

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,8 @@ sonar.python.version=3.13
 
 sonar.sources=.
 sonar.tests=.
-sonar.test.inclusions=backend/tests/**,frontend/src/**/*.test.js,frontend/e2e/**
-sonar.exclusions=backend/tests/**,frontend/src/**/*.test.js,frontend/e2e/**,backend/vendor/**,frontend/node_modules/**,frontend/dist/**,frontend/coverage/**,backend/build/**,artifacts/**,prototype/**,**/*.png,**/*.woff2,**/*.pdf
+sonar.test.inclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**
+sonar.exclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,backend/vendor/**,frontend/node_modules/**,frontend/dist/**,frontend/coverage/**,backend/build/**,artifacts/**,prototype/**,**/*.png,**/*.woff2,**/*.pdf
 
 sonar.php.coverage.reportPaths=backend/build/coverage/clover.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,13 @@
+sonar.organization=antropophag
+sonar.projectKey=Antropophag_ic
+sonar.projectName=ic
+sonar.sourceEncoding=UTF-8
+sonar.python.version=3.13
+
+sonar.sources=.
+sonar.tests=.
+sonar.test.inclusions=backend/tests/**,frontend/src/**/*.test.js,frontend/e2e/**
+sonar.exclusions=backend/tests/**,frontend/src/**/*.test.js,frontend/e2e/**,backend/vendor/**,frontend/node_modules/**,frontend/dist/**,frontend/coverage/**,backend/build/**,artifacts/**,prototype/**,**/*.png,**/*.woff2,**/*.pdf
+
+sonar.php.coverage.reportPaths=backend/build/coverage/clover.xml
+sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info


### PR DESCRIPTION
## Цель

Перевести проект с Automatic Analysis на CI-based SonarQube Cloud analysis, чтобы импортировать существующее покрытие и проверять Quality Gate на изменениях pull request.

## Изменения

- Sonar запускается после deterministic CI jobs с полным Git history.
- Переиспользуется PHPUnit Clover; container paths нормализуются в скачанной копии artifact.
- Vitest дополнительно формирует LCOV без изменения тестов и порогов.
- Quality Gate применяется к new code; historical debt сам по себе не блокирует PR.
- Токен читается только из GitHub Secret `SONAR_TOKEN`.

Automatic Analysis для проекта уже выключен.

## Проверка

- `make check`
- PHPUnit: 367 tests, 722 assertions
- Vitest: 261 tests
- PHPStan, ESLint, production build, dependency audits, OpenAPI validation
- `actionlint`
- repository lint
- `git diff --check`
- локальный CI-based Sonar scan с импортом Clover и LCOV; Quality Gate `OK`
- независимый `pr-review`: actionable findings отсутствуют

## Риск и откат

Риск ограничен CI: application runtime не меняется. Откат — удалить Sonar job/config и LCOV reporter; существующие deterministic checks остаются без изменений.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added automated SonarQube Cloud code-quality and security analysis for the main branch and pull requests.
  * Added PHP and frontend coverage report uploads to support SonarQube analysis.
  * Added LCOV coverage report generation for frontend tests.
  * Added consistent project settings for source, test, and coverage analysis.

* **Documentation**
  * Documented SonarQube CI integration, coverage handling, baselines, and limitations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->