### PR TITLE
refactor(request): extract persistence adapters

### DIFF
--- a/backend/config/common.php
+++ b/backend/config/common.php
@@ -11,6 +11,14 @@ return [
     'basePath' => dirname(__DIR__),
     'vendorPath' => dirname(__DIR__) . '/vendor',
     'bootstrap' => ['log'],
+    'container' => [
+        'definitions' => [
+            App\Application\Request\Port\RequestColorGateway::class => static fn () =>
+                new App\Infrastructure\Persistence\Request\RequestColorPersistenceAdapter(Yii::$app->db),
+            App\Application\Request\Port\RequestDepartmentGateway::class => static fn () =>
+                new App\Infrastructure\Persistence\Request\RequestDepartmentPersistenceAdapter(Yii::$app->db),
+        ],
+    ],
     'components' => [
         'db' => [
             'class' => yii\db\Connection::class,

--- a/backend/phpunit.coverage.xml
+++ b/backend/phpunit.coverage.xml
@@ -31,7 +31,8 @@
             <file>src/Infrastructure/Import/BitrixArchiveFileImporter.php</file>
             <file>src/Infrastructure/Admin/AuditQuery.php</file>
             <file>src/Infrastructure/Request/RequestRepository.php</file>
-            <file>src/Infrastructure/Request/RequestDepartmentPersistence.php</file>
+            <file>src/Infrastructure/Persistence/Request/RequestColorPersistenceAdapter.php</file>
+            <file>src/Infrastructure/Persistence/Request/RequestDepartmentPersistenceAdapter.php</file>
             <file>src/Http/Controller/RequestController.php</file>
             <file>src/Http/Request/ChangeDepartmentRequest.php</file>
             <file>migrations/m260810_000001_add_bitrix_archive_metadata.php</file>

--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -410,7 +410,7 @@ final class RequestController extends ApiController
             return $errors;
         }
         try {
-            $result = (new ChangeRequestDepartment($this->repository()))->execute(
+            $result = Yii::$container->get(ChangeRequestDepartment::class)->execute(
                 $input->toCommand($id, $this->currentUserId()),
             );
             return $result->toArray();
@@ -432,7 +432,7 @@ final class RequestController extends ApiController
         }
         $actorId = $this->currentUserId();
         try {
-            $result = (new SetRequestColor($this->repository()))->execute($input->toCommand($id, $actorId));
+            $result = Yii::$container->get(SetRequestColor::class)->execute($input->toCommand($id, $actorId));
             return $result->toArray();
         } catch (RequestNotFound $error) {
             throw new NotFoundHttpException($error->getMessage());

--- a/backend/src/Infrastructure/Persistence/Request/RequestColorPersistenceAdapter.php
+++ b/backend/src/Infrastructure/Persistence/Request/RequestColorPersistenceAdapter.php
@@ -1,0 +1,85 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Request;
+
+use App\Application\Request\Port\RequestColorGateway;
+use App\Domain\Request\RequestColor;
+use App\Domain\Request\Role;
+use App\Infrastructure\Clock;
+use yii\db\Connection;
+
+final readonly class RequestColorPersistenceAdapter implements RequestColorGateway
+{
+    public function __construct(private Connection $db)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        $transaction = $this->db->beginTransaction();
+        try {
+            $result = $operation();
+            $transaction->commit();
+            return $result;
+        } catch (\Throwable $error) {
+            $transaction->rollBack();
+            throw $error;
+        }
+    }
+
+    public function lockVersionForUpdate(int $requestId): ?int
+    {
+        $lockVersion = $this->db->createCommand(
+            'SELECT lock_version FROM {{%requests}} WHERE id = :id FOR UPDATE',
+            [':id' => $requestId],
+        )->queryScalar();
+        return $lockVersion === false ? null : (int) $lockVersion;
+    }
+
+    /** @return list<Role> */
+    public function rolesFor(int $actorId): array
+    {
+        $codes = $this->db->createCommand(
+            'SELECT r.code FROM {{%roles}} r '
+            . 'JOIN {{%user_roles}} ur ON ur.role_id = r.id WHERE ur.user_id = :user_id',
+            [':user_id' => $actorId],
+        )->queryColumn();
+
+        return array_values(array_filter(array_map(
+            static fn (string $code): ?Role => Role::tryFrom($code),
+            $codes,
+        )));
+    }
+
+    public function isActiveUser(int $actorId): bool
+    {
+        return $this->db->createCommand(
+            'SELECT 1 FROM {{%users}} WHERE id = :id AND is_active = 1',
+            [':id' => $actorId],
+        )->queryScalar() !== false;
+    }
+
+    public function persistColorChange(int $requestId, RequestColor $color, int $lockVersion): void
+    {
+        $this->db->createCommand()->update('{{%requests}}', [
+            'color' => $color->value,
+            'lock_version' => $lockVersion,
+            'updated_at' => Clock::now(),
+        ], ['id' => $requestId])->execute();
+    }
+
+    public function recordColorMarked(int $requestId, int $actorId, RequestColor $color, string $ruleId): void
+    {
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.color_marked',
+            'entity_type' => 'request',
+            'entity_id' => $requestId,
+            'actor_id' => $actorId,
+            'rule_id' => $ruleId,
+            'payload_json' => ['color' => $color->value],
+            'created_at' => Clock::now(),
+        ])->execute();
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Request/RequestDepartmentPersistenceAdapter.php
+++ b/backend/src/Infrastructure/Persistence/Request/RequestDepartmentPersistenceAdapter.php
@@ -2,14 +2,33 @@
 
 declare(strict_types=1);
 
-namespace App\Infrastructure\Request;
+namespace App\Infrastructure\Persistence\Request;
 
 use App\Application\Request\ChangeRequestDepartmentResult;
 use App\Application\Request\DepartmentChangeSnapshot;
+use App\Application\Request\Port\RequestDepartmentGateway;
 use App\Infrastructure\Clock;
+use yii\db\Connection;
 
-trait RequestDepartmentPersistence
+final readonly class RequestDepartmentPersistenceAdapter implements RequestDepartmentGateway
 {
+    public function __construct(private Connection $db)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        $transaction = $this->db->beginTransaction();
+        try {
+            $result = $operation();
+            $transaction->commit();
+            return $result;
+        } catch (\Throwable $error) {
+            $transaction->rollBack();
+            throw $error;
+        }
+    }
+
     public function lockAdministratorRole(int $actorId): bool
     {
         return $this->db->createCommand(
@@ -89,6 +108,14 @@ trait RequestDepartmentPersistence
 
     public function departmentChangeResult(int $requestId): ChangeRequestDepartmentResult
     {
-        return new ChangeRequestDepartmentResult($this->findOne($requestId));
+        $request = $this->db->createCommand(
+            'SELECT id, number, legacy_id, initiator_id, status, product_name, manufacturer, supplier, '
+            . 'sample_quantity, legacy_sample_quantity_raw, test_method, revision, lock_version, color, '
+            . 'department_name AS department, '
+            . 'created_at, updated_at FROM {{%requests}} WHERE id = :id',
+            [':id' => $requestId],
+        )->queryOne();
+
+        return new ChangeRequestDepartmentResult($request);
     }
 }

--- a/backend/src/Infrastructure/Request/RequestRepository.php
+++ b/backend/src/Infrastructure/Request/RequestRepository.php
@@ -5,8 +5,6 @@ declare(strict_types=1);
 namespace App\Infrastructure\Request;
 
 use App\Application\Request\CreateRequestInput;
-use App\Application\Request\Port\RequestColorGateway;
-use App\Application\Request\Port\RequestDepartmentGateway;
 use App\Domain\Request\CommentPolicy;
 use App\Domain\Request\AssignmentPolicy;
 use App\Domain\Request\AssignmentTargetNotFound;
@@ -15,7 +13,6 @@ use App\Domain\Request\ExpertAssignmentPolicy;
 use App\Domain\Request\RequestAction;
 use App\Domain\Request\RejectPolicy;
 use App\Domain\Request\RequestCreationPolicy;
-use App\Domain\Request\RequestColor;
 use App\Domain\Request\RequestDepartmentMissing;
 use App\Domain\Request\RequestNotFound;
 use App\Domain\Request\RequestStatus;
@@ -29,10 +26,8 @@ use App\Infrastructure\Clock;
 use App\Infrastructure\Notification\NotificationOutbox;
 use yii\db\Connection;
 
-final class RequestRepository implements RequestColorGateway, RequestDepartmentGateway
+final class RequestRepository
 {
-    use RequestDepartmentPersistence;
-
     public function __construct(private readonly Connection $db)
     {
     }
@@ -696,50 +691,6 @@ final class RequestRepository implements RequestColorGateway, RequestDepartmentG
             'actor_id' => $actorId,
             'rule_id' => $ruleId,
             'payload_json' => ['executor_id' => $executorId],
-            'created_at' => Clock::now(),
-        ])->execute();
-    }
-
-    public function transactional(callable $operation): mixed
-    {
-        $transaction = $this->db->beginTransaction();
-        try {
-            $result = $operation();
-            $transaction->commit();
-            return $result;
-        } catch (\Throwable $error) {
-            $transaction->rollBack();
-            throw $error;
-        }
-    }
-
-    public function lockVersionForUpdate(int $requestId): ?int
-    {
-        $lockVersion = $this->db->createCommand(
-            'SELECT lock_version FROM {{%requests}} WHERE id = :id FOR UPDATE',
-            [':id' => $requestId],
-        )->queryScalar();
-        return $lockVersion === false ? null : (int) $lockVersion;
-    }
-
-    public function persistColorChange(int $requestId, RequestColor $color, int $lockVersion): void
-    {
-        $this->db->createCommand()->update('{{%requests}}', [
-            'color' => $color->value,
-            'lock_version' => $lockVersion,
-            'updated_at' => Clock::now(),
-        ], ['id' => $requestId])->execute();
-    }
-
-    public function recordColorMarked(int $requestId, int $actorId, RequestColor $color, string $ruleId): void
-    {
-        $this->db->createCommand()->insert('{{%audit_events}}', [
-            'event_type' => 'request.color_marked',
-            'entity_type' => 'request',
-            'entity_id' => $requestId,
-            'actor_id' => $actorId,
-            'rule_id' => $ruleId,
-            'payload_json' => ['color' => $color->value],
             'created_at' => Clock::now(),
         ])->execute();
     }

--- a/backend/tests/Integration/Http/ChangeRequestDepartmentHttpTest.php
+++ b/backend/tests/Integration/Http/ChangeRequestDepartmentHttpTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Integration\Http;
 
 use App\Application\Request\CreateRequestInput;
+use App\Application\Request\Port\RequestDepartmentGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Request\RequestRepository;
+use App\Infrastructure\Persistence\Request\RequestDepartmentPersistenceAdapter;
 use Tests\Integration\IntegrationTestCase;
 use Yii;
 use yii\web\Application;
@@ -117,6 +119,11 @@ final class ChangeRequestDepartmentHttpTest extends IntegrationTestCase
             'id' => 'change-request-department-http-test',
             'basePath' => dirname(__DIR__, 3),
             'params' => ['identityHeader' => 'X-Test-User-ID'],
+            'container' => [
+                'definitions' => [
+                    RequestDepartmentGateway::class => fn () => new RequestDepartmentPersistenceAdapter($this->db()),
+                ],
+            ],
             'components' => [
                 'db' => $this->db(),
                 'request' => ['class' => Request::class, 'cookieValidationKey' => 'department-http-test'],

--- a/backend/tests/Integration/Http/SetRequestColorHttpTest.php
+++ b/backend/tests/Integration/Http/SetRequestColorHttpTest.php
@@ -5,8 +5,10 @@ declare(strict_types=1);
 namespace Tests\Integration\Http;
 
 use App\Application\Request\CreateRequestInput;
+use App\Application\Request\Port\RequestColorGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Request\RequestRepository;
+use App\Infrastructure\Persistence\Request\RequestColorPersistenceAdapter;
 use Tests\Integration\IntegrationTestCase;
 use Yii;
 use yii\web\Application;
@@ -110,6 +112,11 @@ final class SetRequestColorHttpTest extends IntegrationTestCase
             'id' => 'set-request-color-http-test',
             'basePath' => dirname(__DIR__, 3),
             'params' => ['identityHeader' => 'X-Test-User-ID'],
+            'container' => [
+                'definitions' => [
+                    RequestColorGateway::class => fn () => new RequestColorPersistenceAdapter($this->db()),
+                ],
+            ],
             'components' => [
                 'db' => $this->db(),
                 'request' => ['class' => Request::class, 'cookieValidationKey' => 'set-request-color-http-test'],

--- a/backend/tests/Integration/Request/ChangeRequestDepartmentAuditAtomicityTest.php
+++ b/backend/tests/Integration/Request/ChangeRequestDepartmentAuditAtomicityTest.php
@@ -7,6 +7,7 @@ namespace Tests\Integration\Request;
 use App\Application\Request\Command\ChangeRequestDepartmentCommand;
 use App\Application\Request\CreateRequestInput;
 use App\Application\Request\UseCase\ChangeRequestDepartment;
+use App\Infrastructure\Persistence\Request\RequestDepartmentPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
 use PHPUnit\Framework\TestCase;
 use yii\db\Connection;
@@ -40,7 +41,7 @@ final class ChangeRequestDepartmentAuditAtomicityTest extends TestCase
             ], ['id' => $request['id']])->execute();
 
             try {
-                (new ChangeRequestDepartment($repository))->execute(new ChangeRequestDepartmentCommand(
+                (new ChangeRequestDepartment(new RequestDepartmentPersistenceAdapter($db)))->execute(new ChangeRequestDepartmentCommand(
                     (int) $request['id'],
                     'Новое подразделение',
                     (int) $request['lock_version'],

--- a/backend/tests/Integration/Request/RequestRepositoryTest.php
+++ b/backend/tests/Integration/Request/RequestRepositoryTest.php
@@ -17,6 +17,7 @@ use App\Domain\Request\SuspendResumeDenied;
 use App\Domain\Request\WithdrawDenied;
 use App\Infrastructure\Admin\AuditQuery;
 use App\Infrastructure\Clock;
+use App\Infrastructure\Persistence\Request\RequestDepartmentPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
 use App\Infrastructure\Request\RequestQuery;
 use Tests\Integration\IntegrationTestCase;
@@ -106,7 +107,7 @@ final class RequestRepositoryTest extends IntegrationTestCase
         $request = $this->createRegisteredRequest($initiator, 'department-manual');
         $this->db()->createCommand()->update('{{%requests}}', ['department_external_id' => 'bitrix:42'], ['id' => $request['id']])->execute();
 
-        $result = (new ChangeRequestDepartment(new RequestRepository($this->db())))->execute(
+        $result = (new ChangeRequestDepartment(new RequestDepartmentPersistenceAdapter($this->db())))->execute(
             new ChangeRequestDepartmentCommand(
                 (int) $request['id'],
                 'Подразделение C',
@@ -143,7 +144,7 @@ final class RequestRepositoryTest extends IntegrationTestCase
         $initiator = $this->createUser('dev.it.department.denied', 'Инициатор');
         $request = $this->createRegisteredRequest($initiator, 'department-denied');
         $this->expectException(RequestDepartmentChangeDenied::class);
-        (new ChangeRequestDepartment(new RequestRepository($this->db())))->execute(
+        (new ChangeRequestDepartment(new RequestDepartmentPersistenceAdapter($this->db())))->execute(
             new ChangeRequestDepartmentCommand(
                 (int) $request['id'],
                 'Другое подразделение',
@@ -165,7 +166,7 @@ final class RequestRepositoryTest extends IntegrationTestCase
         ], ['id' => $request['id']])->execute();
 
         try {
-            (new ChangeRequestDepartment(new RequestRepository($this->db())))->execute(
+            (new ChangeRequestDepartment(new RequestDepartmentPersistenceAdapter($this->db())))->execute(
                 new ChangeRequestDepartmentCommand(
                     (int) $request['id'],
                     'Новое подразделение',

--- a/backend/tests/Integration/Request/SetRequestColorAuditAtomicityTest.php
+++ b/backend/tests/Integration/Request/SetRequestColorAuditAtomicityTest.php
@@ -8,6 +8,7 @@ use App\Application\Request\Command\SetRequestColorCommand;
 use App\Application\Request\CreateRequestInput;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Domain\Request\RequestColor;
+use App\Infrastructure\Persistence\Request\RequestColorPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
 use PHPUnit\Framework\TestCase;
 use yii\db\Connection;
@@ -37,7 +38,7 @@ final class SetRequestColorAuditAtomicityTest extends TestCase
             $request = $repository->create($input, $initiatorId);
 
             try {
-                (new SetRequestColor($repository))->execute(new SetRequestColorCommand(
+                (new SetRequestColor(new RequestColorPersistenceAdapter($db)))->execute(new SetRequestColorCommand(
                     (int) $request['id'],
                     RequestColor::Red,
                     (int) $request['lock_version'],

--- a/backend/tests/Integration/Request/SetRequestColorTest.php
+++ b/backend/tests/Integration/Request/SetRequestColorTest.php
@@ -11,6 +11,7 @@ use App\Domain\Request\ColorMarkDenied;
 use App\Domain\Request\ConcurrentRequestModification;
 use App\Domain\Request\RequestColor;
 use App\Domain\Request\RequestNotFound;
+use App\Infrastructure\Persistence\Request\RequestColorPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
 use Tests\Integration\IntegrationTestCase;
 
@@ -103,7 +104,7 @@ final class SetRequestColorTest extends IntegrationTestCase
 
     private function useCase(): SetRequestColor
     {
-        return new SetRequestColor(new RequestRepository($this->db()));
+        return new SetRequestColor(new RequestColorPersistenceAdapter($this->db()));
     }
 
     private function assertDeniedWithoutMutation(int $requestId, int $lockVersion, int $actorId, string $ruleId): void

--- a/backend/tools/architecture-baseline.php
+++ b/backend/tools/architecture-baseline.php
@@ -82,7 +82,7 @@ return [
         'backend/src/Http/Controller/RequestController.php' => 899,
         'backend/src/Infrastructure/Document/DocumentRepository.php' => 782,
         'backend/src/Infrastructure/Request/RequestQuery.php' => 646,
-        'backend/src/Infrastructure/Request/RequestRepository.php' => 1402,
+        'backend/src/Infrastructure/Request/RequestRepository.php' => 1353,
         'frontend/src/components/RequestDetails.vue' => 1272,
         'frontend/src/components/RequestRegistry.vue' => 847,
     ],


### PR DESCRIPTION
## Цель

Физически вынести persistence-реализации уже существующих Application ports из большого `RequestRepository` без изменения бизнес-семантики Wave 4.

## Изменения

- `RequestColorGateway` и `RequestDepartmentGateway` теперь реализуются отдельными adapters в `Infrastructure/Persistence/Request`.
- `RequestRepository` больше не реализует эти ports.
- Transitional `RequestDepartmentPersistence` удалён.
- Application ports намеренно не объединялись: сходство transaction primitives пока недостаточно для общей abstraction.
- Transaction boundaries, `FOR UPDATE`, lock ordering, optimistic concurrency, audit atomicity, timestamps и API semantics не изменились.
- `RequestRepository`: 1402 → 1353 LOC.
- Production diff: +217/−146.
- Tests/quality diff: +27/−8.
- Architecture baseline не ухудшился; hotspot baseline `RequestRepository` уменьшился.

## Проверки

Первый E2E-прогон выявил отсутствующие DI bindings в manually-created test applications. Test fixtures исправлены; после этого полный набор проверок повторно прошёл:

- `make check` — passed;
- `make e2e` — passed: 260 integration tests / 1762 assertions, 16 Playwright tests, runtime contracts;
- `make coverage` — passed: 511 backend tests, Domain/Application 93.53%; frontend 96.57% lines;
- отдельный read-only `$pr-review` — actionable findings отсутствуют.

## Риски и откат

Риск ограничен production persistence composition path двух уже мигрированных slices. Откат — revert единственного commit этого PR; migrations и данные не менялись.

Wave 5 в этот PR не входит.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when changing request departments or colors by ensuring database updates and audit records complete atomically.
  * Added safer handling for concurrent updates and invalid or inactive actors.

* **Refactor**
  * Separated request color and department persistence responsibilities, improving maintainability without changing the existing user-facing workflows.

* **Tests**
  * Updated integration coverage for department changes, color updates, rollback behavior, authorization, and stale updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->