### PR TITLE
test(coverage): automate backend coverage contour

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,7 +119,7 @@ coverage: doctor
 	mkdir -p backend/build/coverage
 	python3 -m venv backend/build/coverage/python-venv
 	backend/build/coverage/python-venv/bin/pip install --disable-pip-version-check -r scripts/requirements-coverage.txt
-	COVERAGE_FILE=backend/build/coverage/.coverage backend/build/coverage/python-venv/bin/coverage run --include='scripts/check_coverage.py' -m unittest discover -s scripts/tests
+	COVERAGE_FILE=backend/build/coverage/.coverage backend/build/coverage/python-venv/bin/coverage run --include='scripts/check_coverage*.py' -m unittest discover -s scripts/tests
 	COVERAGE_FILE=backend/build/coverage/.coverage backend/build/coverage/python-venv/bin/coverage xml -o backend/build/coverage/python.xml
 	$(CONTAINER_ENGINE) build --file docker/coverage.Dockerfile --tag shlz-test-registry-coverage .
 	COMPOSE='$(COMPOSE)' CONTAINER_ENGINE='$(CONTAINER_ENGINE)' sh scripts/backend-coverage.sh

--- a/backend/phpunit.coverage.xml
+++ b/backend/phpunit.coverage.xml
@@ -5,60 +5,12 @@
             <directory>tests/Unit</directory>
         </testsuite>
         <testsuite name="covered-integration">
-            <file>tests/Integration/Identity/UserAdministrationRepositoryTest.php</file>
-            <file>tests/Integration/Identity/UserRoleAuditAtomicityTest.php</file>
-            <file>tests/Integration/Import/BitrixArchiveFileImporterTest.php</file>
-            <file>tests/Integration/Import/BitrixArchiveMetadataMigrationTest.php</file>
-            <file>tests/Integration/Request/RequestRepositoryTest.php</file>
-            <file>tests/Integration/Request/RequestCreationAuditAtomicityTest.php</file>
-            <file>tests/Integration/Request/SetRequestColorTest.php</file>
-            <file>tests/Integration/Request/SetRequestColorAuditAtomicityTest.php</file>
-            <file>tests/Integration/Http/SetRequestColorHttpTest.php</file>
-            <file>tests/Integration/Request/ChangeRequestDepartmentAuditAtomicityTest.php</file>
-            <file>tests/Integration/Http/ChangeRequestDepartmentHttpTest.php</file>
-            <file>tests/Integration/Request/RequestLifecycleAtomicityTest.php</file>
-            <file>tests/Integration/Http/RequestLifecycleHttpTest.php</file>
-            <file>tests/Integration/Request/RequestCancellationAtomicityTest.php</file>
-            <file>tests/Integration/Http/RequestCancellationHttpTest.php</file>
-            <file>tests/Integration/Request/ExecutorAssignmentAtomicityTest.php</file>
-            <file>tests/Integration/Http/ExecutorAssignmentHttpTest.php</file>
-            <file>tests/Integration/Document/DocumentRepositoryTest.php</file>
-            <file>tests/Integration/Notification/NotificationOutboxCredentialCleanupTest.php</file>
-            <file>tests/Integration/Notification/NotificationOutboxMigrationResumabilityTest.php</file>
-            <file>tests/Integration/Notification/NotificationOutboxProcessorTest.php</file>
+            <directory>tests/Integration</directory>
         </testsuite>
     </testsuites>
     <source>
         <include>
-            <directory>src/Domain</directory>
-            <directory>src/Application</directory>
-            <file>tools/ArchitectureGuard.php</file>
-            <file>src/Infrastructure/Identity/UserAdministrationRepository.php</file>
-            <file>src/Infrastructure/Import/BitrixArchiveFileImporter.php</file>
-            <file>src/Infrastructure/Admin/AuditQuery.php</file>
-            <file>src/Infrastructure/Request/RequestRepository.php</file>
-            <file>src/Infrastructure/Persistence/Request/RequestColorPersistenceAdapter.php</file>
-            <file>src/Infrastructure/Persistence/Request/RequestDepartmentPersistenceAdapter.php</file>
-            <file>src/Infrastructure/Persistence/Request/RequestLifecyclePersistenceAdapter.php</file>
-            <file>src/Infrastructure/Persistence/Request/RequestCancellationPersistenceAdapter.php</file>
-            <file>src/Infrastructure/Persistence/Request/ExecutorAssignmentPersistenceAdapter.php</file>
-            <file>src/Http/Controller/RequestController.php</file>
-            <file>src/Http/Request/AssignExecutorRequest.php</file>
-            <file>src/Http/Request/ChangeDepartmentRequest.php</file>
-            <file>src/Http/Request/LockVersionRequest.php</file>
-            <file>src/Http/Request/ReasonedLockVersionRequest.php</file>
-            <file>src/Http/Request/CancelRequest.php</file>
-            <file>migrations/m260810_000001_add_bitrix_archive_metadata.php</file>
-            <file>migrations/m260813_000001_secure_notification_download_links.php</file>
-            <file>src/Infrastructure/Document/DocumentRepository.php</file>
-            <file>src/Infrastructure/Notification/DownloadLinkSigningKey.php</file>
-            <file>src/Infrastructure/Notification/InvalidNotificationPayload.php</file>
-            <file>src/Infrastructure/Notification/InvalidDownloadLinkConfiguration.php</file>
-            <file>src/Infrastructure/Notification/NotificationDownloadLinks.php</file>
-            <file>src/Infrastructure/Notification/NotificationDocumentLinksPayload.php</file>
-            <file>src/Infrastructure/Notification/NotificationOutbox.php</file>
-            <file>src/Infrastructure/Notification/NotificationOutboxCredentialCleanup.php</file>
-            <file>src/Infrastructure/Notification/NotificationOutboxProcessor.php</file>
+            <directory>src</directory>
         </include>
     </source>
 </phpunit>

--- a/docs/test-strategy.md
+++ b/docs/test-strategy.md
@@ -12,6 +12,12 @@ backend-уровень — Integration с настоящей MariaDB; брауз
 | Playwright | вход и критические маршруты через реальный `frontend` | `make e2e` |
 | Runtime contracts | LDAP/SMTP/MariaDB/scheduler recovery | `make e2e` |
 
+Backend coverage автоматически включает весь production-код `backend/src` и
+все `*Test.php` из `backend/tests/Integration`; migrations, tools, vendor и test
+code в coverage source не входят. `make check` проверяет этот контракт и его
+согласованность с Sonar, поэтому новые production-классы и integration tests не
+требуют ручного изменения `phpunit.coverage.xml`.
+
 ## Единый стенд
 
 ```text

--- a/scripts/check_coverage_contour.py
+++ b/scripts/check_coverage_contour.py
@@ -1,0 +1,165 @@
+#!/usr/bin/env python3
+"""Keep PHPUnit's coverage contour aligned with Sonar and repository layout."""
+
+from __future__ import annotations
+
+import argparse
+import fnmatch
+import xml.etree.ElementTree as ET
+from pathlib import Path
+
+
+EXPECTED_SONAR_COVERAGE_EXCLUSIONS = (
+    "backend/migrations/**",
+    "backend/tools/architecture-guard.php",
+    "backend/tools/architecture-baseline.php",
+)
+
+
+def properties(path: Path) -> dict[str, str]:
+    result: dict[str, str] = {}
+    for raw_line in path.read_text(encoding="utf-8").splitlines():
+        line = raw_line.strip()
+        if line and not line.startswith("#") and "=" in line:
+            key, value = line.split("=", 1)
+            result[key.strip()] = value.strip()
+    return result
+
+
+def patterns(value: str) -> tuple[str, ...]:
+    return tuple(pattern.strip() for pattern in value.split(",") if pattern.strip())
+
+
+def matches(path: str, candidates: tuple[str, ...]) -> bool:
+    return any(fnmatch.fnmatchcase(path, candidate) for candidate in candidates)
+
+
+def is_sonar_source(path: str, candidates: tuple[str, ...]) -> bool:
+    return any(
+        candidate == "."
+        or path == candidate.rstrip("/")
+        or path.startswith(f"{candidate.rstrip('/')}/")
+        for candidate in candidates
+    )
+
+
+def xml_paths(parent: ET.Element, backend: Path, tag: str, suffix: str) -> set[Path]:
+    paths: set[Path] = set()
+    for node in parent.findall(tag):
+        if not node.text or not node.text.strip():
+            continue
+        candidate = backend / node.text.strip()
+        if tag == "directory":
+            paths.update(candidate.rglob(f"*{suffix}"))
+        elif candidate.is_file():
+            paths.add(candidate)
+    return {path.resolve() for path in paths}
+
+
+def validate(root: Path) -> list[str]:
+    root = root.resolve()
+    backend = root / "backend"
+    config_path = backend / "phpunit.coverage.xml"
+    tree = ET.parse(config_path)
+    errors: list[str] = []
+
+    source = tree.find("source/include")
+    if source is None:
+        return ["phpunit.coverage.xml has no <source><include> contour"]
+    if tree.find("source/exclude") is not None:
+        errors.append("coverage source must not have manual <exclude> entries")
+    source_directory_nodes = source.findall("directory")
+    source_directories = [node.text.strip() for node in source_directory_nodes if node.text]
+    source_files = source.findall("file")
+    if (
+        source_directories != ["src"]
+        or source_files
+        or any(node.attrib for node in source_directory_nodes)
+    ):
+        errors.append(
+            "coverage source must be the unfiltered directory 'src'; manual files or "
+            "directory filters are stale"
+        )
+
+    suites = {
+        suite.attrib.get("name", ""): suite for suite in tree.findall("testsuites/testsuite")
+    }
+    integration = suites.get("covered-integration")
+    if integration is None:
+        errors.append("phpunit.coverage.xml has no covered-integration suite")
+        return errors
+    integration_directory_nodes = integration.findall("directory")
+    integration_directories = [
+        node.text.strip() for node in integration_directory_nodes if node.text
+    ]
+    if (
+        integration_directories != ["tests/Integration"]
+        or integration.findall("file")
+        or any(node.attrib for node in integration_directory_nodes)
+    ):
+        errors.append(
+            "covered-integration must use the unfiltered tests/Integration directory; "
+            "manual files or directory filters are stale"
+        )
+    if integration.findall("exclude"):
+        errors.append("covered-integration must not have manual <exclude> entries")
+
+    if tree.find("groups") is not None:
+        errors.append("coverage integration discovery must not have manual group filters")
+
+    sonar = properties(root / "sonar-project.properties")
+    sonar_sources = patterns(sonar.get("sonar.sources", ""))
+    sonar_exclusions = patterns(sonar.get("sonar.exclusions", ""))
+    sonar_test_inclusions = patterns(sonar.get("sonar.test.inclusions", ""))
+    sonar_coverage_exclusions = patterns(sonar.get("sonar.coverage.exclusions", ""))
+    if sonar_coverage_exclusions != EXPECTED_SONAR_COVERAGE_EXCLUSIONS:
+        errors.append(
+            "Sonar coverage exclusions must contain only migrations and the two "
+            "architecture guard files; stale or blanket exclusions are forbidden"
+        )
+    production = {path.resolve() for path in (backend / "src").rglob("*.php")}
+    sonar_production = {
+        path
+        for path in production
+        if is_sonar_source(path.relative_to(root).as_posix(), sonar_sources)
+        and not matches(path.relative_to(root).as_posix(), sonar_exclusions)
+    }
+    covered_source = xml_paths(source, backend, "directory", ".php") | xml_paths(
+        source, backend, "file", ".php"
+    )
+    for path in sorted(sonar_production - covered_source):
+        errors.append(f"Sonar production file is outside PHPUnit coverage source: {path.relative_to(root)}")
+
+    integration_tests = {
+        path.resolve() for path in (backend / "tests/Integration").rglob("*Test.php")
+    }
+    for path in sorted(integration_tests):
+        relative = path.relative_to(root).as_posix()
+        if not matches(relative, sonar_test_inclusions):
+            errors.append(f"integration test is outside Sonar test inclusions: {relative}")
+
+    discovered_tests = xml_paths(integration, backend, "directory", "Test.php") | xml_paths(
+        integration, backend, "file", "Test.php"
+    )
+    for path in sorted(integration_tests - discovered_tests):
+        errors.append(f"coverage-relevant integration test is not discovered: {path.relative_to(root)}")
+
+    return errors
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--root", type=Path, default=Path(__file__).resolve().parent.parent)
+    args = parser.parse_args()
+    errors = validate(args.root)
+    if errors:
+        print("Coverage contour violations:")
+        for error in errors:
+            print(f"- {error}")
+        return 1
+    print("Coverage contour is self-maintaining: backend/src and relevant Integration tests are discovered.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/lint-repository.sh
+++ b/scripts/lint-repository.sh
@@ -19,6 +19,8 @@ sh scripts/check-deployment-contracts.sh
 sh scripts/check-review-contracts.sh
 sh scripts/test-review-contracts.sh
 sh scripts/test-git-push-identity.sh
+python3 scripts/check_coverage_contour.py
+python3 -m unittest scripts.tests.test_check_coverage_contour
 if command -v yamllint >/dev/null 2>&1; then
   yamllint -c .yamllint.yml .
 elif command -v uvx >/dev/null 2>&1; then

--- a/scripts/tests/test_check_coverage_contour.py
+++ b/scripts/tests/test_check_coverage_contour.py
@@ -1,0 +1,184 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+
+from scripts import check_coverage_contour
+
+
+class CheckCoverageContourTest(unittest.TestCase):
+    def setUp(self) -> None:
+        self.temporary = tempfile.TemporaryDirectory()
+        self.root = Path(self.temporary.name)
+        (self.root / "backend/src/Application").mkdir(parents=True)
+        (self.root / "backend/tests/Integration/Request").mkdir(parents=True)
+        (self.root / "backend/src/Application/Existing.php").write_text("<?php\n", encoding="utf-8")
+        (self.root / "backend/tests/Integration/Request/ExistingTest.php").write_text(
+            "<?php\n", encoding="utf-8"
+        )
+        self.write_config()
+        (self.root / "sonar-project.properties").write_text(
+            "sonar.sources=.\n"
+            "sonar.tests=.\n"
+            "sonar.test.inclusions=backend/tests/**\n"
+            "sonar.exclusions=backend/tests/**\n"
+            "sonar.coverage.exclusions=backend/migrations/**,backend/tools/architecture-guard.php,backend/tools/architecture-baseline.php\n",
+            encoding="utf-8",
+        )
+
+    def tearDown(self) -> None:
+        self.temporary.cleanup()
+
+    def write_config(
+        self,
+        source: str = "<directory>src</directory>",
+        tests: str = "<directory>tests/Integration</directory>",
+    ) -> None:
+        (self.root / "backend/phpunit.coverage.xml").write_text(
+            f"""<?xml version="1.0"?>
+<phpunit>
+  <testsuites><testsuite name="covered-integration">{tests}</testsuite></testsuites>
+  <source><include>{source}</include></source>
+</phpunit>
+""",
+            encoding="utf-8",
+        )
+
+    def test_new_production_and_integration_files_are_discovered_automatically(self) -> None:
+        (self.root / "backend/src/Application/NewProduction.php").write_text("<?php\n", encoding="utf-8")
+        (self.root / "backend/tests/Integration/Request/NewBehaviorTest.php").write_text(
+            "<?php\n", encoding="utf-8"
+        )
+
+        self.assertEqual([], check_coverage_contour.validate(self.root))
+
+    def test_manual_file_contours_are_rejected_as_stale(self) -> None:
+        self.write_config(
+            source="<file>src/Application/Existing.php</file>",
+            tests="<file>tests/Integration/Request/ExistingTest.php</file>",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("coverage source must be" in error for error in errors))
+        self.assertTrue(any("covered-integration must use" in error for error in errors))
+
+    def test_manual_group_exception_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                "<source>",
+                "<groups><exclude><group>slow</group></exclude></groups><source>",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("must not have manual group filters" in error for error in errors))
+
+    def test_manual_group_include_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                "<source>",
+                "<groups><include><group>covered</group></include></groups><source>",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("must not have manual group filters" in error for error in errors))
+
+    def test_source_directory_filter_is_rejected(self) -> None:
+        self.write_config(source='<directory suffix="Selected.php">src</directory>')
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("coverage source must be the unfiltered" in error for error in errors))
+
+    def test_integration_directory_filter_is_rejected(self) -> None:
+        self.write_config(
+            tests='<directory groups="covered">tests/Integration</directory>',
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("covered-integration must use the unfiltered" in error for error in errors))
+
+    def test_source_exclusion_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                "</source>",
+                "<exclude><directory>src/Infrastructure</directory></exclude></source>",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("coverage source must not have" in error for error in errors))
+
+    def test_integration_suite_exclusion_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                "</testsuite>",
+                "<exclude>tests/Integration/Request</exclude></testsuite>",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("covered-integration must not have" in error for error in errors))
+
+    def test_blanket_sonar_coverage_exclusion_is_rejected(self) -> None:
+        sonar = self.root / "sonar-project.properties"
+        sonar.write_text(
+            sonar.read_text(encoding="utf-8").replace(
+                "backend/migrations/**,backend/tools/architecture-guard.php",
+                "backend/src/Infrastructure/**,backend/tools/architecture-guard.php",
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("stale or blanket exclusions" in error for error in errors))
+
+    def test_missing_source_contour_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                "<source><include><directory>src</directory></include></source>",
+                "<source/>",
+            ),
+            encoding="utf-8",
+        )
+
+        self.assertEqual(
+            ["phpunit.coverage.xml has no <source><include> contour"],
+            check_coverage_contour.validate(self.root),
+        )
+
+    def test_missing_integration_suite_is_rejected(self) -> None:
+        config = self.root / "backend/phpunit.coverage.xml"
+        config.write_text(
+            config.read_text(encoding="utf-8").replace(
+                '<testsuite name="covered-integration">',
+                '<testsuite name="other">',
+            ),
+            encoding="utf-8",
+        )
+
+        errors = check_coverage_contour.validate(self.root)
+
+        self.assertTrue(any("has no covered-integration suite" in error for error in errors))
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -12,4 +12,4 @@ sonar.exclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,scripts/
 sonar.php.coverage.reportPaths=backend/build/coverage/clover.xml
 sonar.python.coverage.reportPaths=backend/build/coverage/python.xml
 sonar.javascript.lcov.reportPaths=frontend/coverage/lcov.info,frontend/coverage/sonar/lcov.info
-sonar.coverage.exclusions=backend/tools/architecture-guard.php,backend/tools/architecture-baseline.php
+sonar.coverage.exclusions=backend/migrations/**,backend/tools/architecture-guard.php,backend/tools/architecture-baseline.php


### PR DESCRIPTION
## Summary

- `phpunit.coverage.xml` automatically includes all production PHP code under `backend/src`
- the complete `backend/tests/Integration` suite is discovered automatically for coverage
- migrations are explicitly excluded from Sonar coverage
- production and integration test files no longer require manual XML entries
- `make check` runs a deterministic coverage-contour guard
- the guard rejects manual `<file>`/`<exclude>` entries, group filters, directory filters, and blanket or stale Sonar coverage exclusions
- a new production file or integration test can no longer silently fall out of the Sonar coverage contour
- the guard itself is included in Python/Sonar coverage

## Linked tasks

Coverage contour remediation requested after Wave 7. Supersedes #278 after addressing hosted SonarCloud and CodeRabbit feedback.

## Metrics

- coverage tests: 558 → 714
- Clover production files: 178/178
- `make coverage`: 62.55 → 163.54 s locally
- first hosted coverage job: 4m16s total; `make coverage` step 4m08s
- Domain/Application coverage: 94.69%
- coverage-contour guard line coverage: 82.8%

The coverage runtime increase is an intentional trade-off: the full integration contour under Xdebug is preferred over a fragile manually maintained test list. A measured attempt to exclude the slow concurrency group did not materially reduce runtime, so no manual test exceptions remain.

## Risks and rollback

Risk is limited to CI runtime and coverage configuration; production behavior is unchanged. Rollback is a normal revert of this single commit, restoring the previous manually maintained contour.

## Validation

- `make coverage`
- `make check`
- `python3 -m unittest discover -s scripts/tests`
- `python3 scripts/check_coverage.py backend/build/coverage/clover.xml --minimum 90`
- generated `backend/build/coverage/python.xml` contains `scripts/check_coverage_contour.py` at 82.8% line coverage
- independent read-only `$pr-review` against `origin/main`, repeated after review fixes

## Labels

`type:maintenance`, `area:ci-cd`, `area:backend`, `area:docs`, `risk:low`

## Readiness

READY pending hosted CI, SonarCloud, and CodeRabbit.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Coverage configuration now automatically includes all production source files and integration tests.
  * Added validation to detect missing or inconsistent coverage settings across PHPUnit and Sonar.

* **Bug Fixes**
  * Excluded database migrations from coverage analysis.

* **Documentation**
  * Updated testing guidance to explain automatic coverage discovery and validation.

* **Tests**
  * Added comprehensive checks for coverage configuration scenarios.
  * Repository linting now includes coverage validation and its tests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->