### PR TITLE
refactor(request): move security decision into application use case

### DIFF
--- a/backend/config/common.php
+++ b/backend/config/common.php
@@ -25,6 +25,8 @@ return [
                 new App\Infrastructure\Persistence\Request\ExecutorAssignmentPersistenceAdapter(Yii::$app->db),
             App\Application\Request\Port\ExpertAssignmentGateway::class => static fn () =>
                 new App\Infrastructure\Persistence\Request\ExpertAssignmentPersistenceAdapter(Yii::$app->db),
+            App\Application\Request\Port\SecurityDecisionGateway::class => static fn () =>
+                new App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter(Yii::$app->db),
         ],
     ],
     'components' => [

--- a/backend/src/Application/Request/Command/DecideSecurityCommand.php
+++ b/backend/src/Application/Request/Command/DecideSecurityCommand.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Command;
+
+final readonly class DecideSecurityCommand
+{
+    public function __construct(
+        public int $requestId,
+        public int $actorId,
+        public string $decision,
+        public ?string $reason,
+        public int $expectedLockVersion,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/Port/SecurityDecisionGateway.php
+++ b/backend/src/Application/Request/Port/SecurityDecisionGateway.php
@@ -1,0 +1,54 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Port;
+
+use App\Application\Request\SecurityDecisionSnapshot;
+use App\Domain\Request\RequestStatus;
+
+interface SecurityDecisionGateway
+{
+    /**
+     * @template T
+     * @param callable(): T $operation
+     * @return T
+     */
+    public function transactional(callable $operation): mixed;
+
+    public function decisionSnapshotForUpdate(int $requestId, int $actorId): ?SecurityDecisionSnapshot;
+
+    public function currentUncheckedOpinionIdForUpdate(int $requestId): ?int;
+
+    public function recordSecurityCheck(
+        int $requestId,
+        int $opinionId,
+        int $actorId,
+        string $decision,
+        ?string $reason,
+        string $decidedAt,
+    ): void;
+
+    public function persistDecision(
+        int $requestId,
+        RequestStatus $targetStatus,
+        int $expectedLockVersion,
+        int $nextLockVersion,
+        string $decidedAt,
+    ): bool;
+
+    public function recordDecision(
+        int $requestId,
+        int $actorId,
+        string $decision,
+        ?string $reason,
+        RequestStatus $targetStatus,
+        string $decidedAt,
+    ): void;
+
+    public function enqueueDecisionNotification(int $requestId, string $decision, ?string $reason): void;
+
+    public function decisionTimestamp(): string;
+
+    public function recordRejectedDecision(int $requestId, int $actorId, string $ruleId): void;
+}

--- a/backend/src/Application/Request/SecurityDecisionResult.php
+++ b/backend/src/Application/Request/SecurityDecisionResult.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+use App\Domain\Request\RequestStatus;
+
+final readonly class SecurityDecisionResult
+{
+    public function __construct(
+        public int $requestId,
+        public string $decision,
+        public RequestStatus $status,
+        public int $lockVersion,
+    ) {
+    }
+
+    /** @return array{requestId: int, decision: string, status: string, lockVersion: int} */
+    public function toArray(): array
+    {
+        return [
+            'requestId' => $this->requestId,
+            'decision' => $this->decision,
+            'status' => $this->status->value,
+            'lockVersion' => $this->lockVersion,
+        ];
+    }
+}

--- a/backend/src/Application/Request/SecurityDecisionSnapshot.php
+++ b/backend/src/Application/Request/SecurityDecisionSnapshot.php
@@ -1,0 +1,20 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+use App\Domain\Request\RequestStatus;
+use App\Domain\Request\Role;
+
+final readonly class SecurityDecisionSnapshot
+{
+    /** @param list<Role> $actorRoles */
+    public function __construct(
+        public RequestStatus $status,
+        public int $lockVersion,
+        public bool $actorIsActive,
+        public array $actorRoles,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/UseCase/DecideSecurity.php
+++ b/backend/src/Application/Request/UseCase/DecideSecurity.php
@@ -1,0 +1,89 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\UseCase;
+
+use App\Application\Request\Command\DecideSecurityCommand;
+use App\Application\Request\Port\SecurityDecisionGateway;
+use App\Application\Request\SecurityDecisionResult;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\RequestNotFound;
+use App\Domain\Request\SecurityDecisionPolicy;
+
+final readonly class DecideSecurity
+{
+    public function __construct(
+        private SecurityDecisionGateway $gateway,
+        private SecurityDecisionPolicy $policy = new SecurityDecisionPolicy(),
+    ) {
+    }
+
+    public function execute(DecideSecurityCommand $command): SecurityDecisionResult
+    {
+        return $this->gateway->transactional(function () use ($command): SecurityDecisionResult {
+            $snapshot = $this->gateway->decisionSnapshotForUpdate($command->requestId, $command->actorId);
+            if ($snapshot === null) {
+                throw new RequestNotFound('Request not found');
+            }
+            $targetStatus = $this->policy->targetStatus(
+                $snapshot->status,
+                $command->decision,
+                $command->reason,
+                $snapshot->actorIsActive,
+                $snapshot->actorRoles,
+            );
+            if ($snapshot->lockVersion !== $command->expectedLockVersion) {
+                throw new ConcurrentRequestModification();
+            }
+            $opinionId = $this->gateway->currentUncheckedOpinionIdForUpdate($command->requestId);
+            if ($opinionId === null) {
+                throw new \RuntimeException('Current expert opinion not found or already checked.');
+            }
+
+            $decidedAt = $this->gateway->decisionTimestamp();
+            $reason = $command->decision === 'return' ? $command->reason : null;
+            $this->gateway->recordSecurityCheck(
+                $command->requestId,
+                $opinionId,
+                $command->actorId,
+                $command->decision,
+                $reason,
+                $decidedAt,
+            );
+            $nextLockVersion = $command->expectedLockVersion + 1;
+            if (
+                !$this->gateway->persistDecision(
+                    $command->requestId,
+                    $targetStatus,
+                    $command->expectedLockVersion,
+                    $nextLockVersion,
+                    $decidedAt,
+                )
+            ) {
+                throw new ConcurrentRequestModification();
+            }
+            $this->gateway->recordDecision(
+                $command->requestId,
+                $command->actorId,
+                $command->decision,
+                $command->reason,
+                $targetStatus,
+                $decidedAt,
+            );
+            $this->gateway->enqueueDecisionNotification($command->requestId, $command->decision, $command->reason);
+
+            return new SecurityDecisionResult(
+                $command->requestId,
+                $command->decision,
+                $targetStatus,
+                $nextLockVersion,
+            );
+        });
+    }
+
+    public function recordRejected(DecideSecurityCommand $command, string $ruleId): void
+    {
+        $this->gateway->recordRejectedDecision($command->requestId, $command->actorId, $ruleId);
+    }
+}

--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -15,8 +15,9 @@ use App\Application\Request\AddCommentInput;
 use App\Application\Request\Command\AssignExpertCommand;
 use App\Application\Request\Command\AssignExecutorCommand;
 use App\Application\Request\Command\CancelRequestCommand;
+use App\Application\Request\Command\DecideSecurityCommand;
 use App\Application\Request\PublishOpinionInput;
-use App\Application\Request\SecurityDecisionInput;
+use App\Application\Request\UseCase\DecideSecurity;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Application\Request\UseCase\RequestLifecycle;
 use App\Application\Request\UseCase\CancelRequest as CancelRequestUseCase;
@@ -58,6 +59,7 @@ use App\Http\Request\ReasonedLockVersionRequest;
 use App\Http\Request\CancelRequest;
 use App\Http\Request\AssignExecutorRequest;
 use App\Http\Request\AssignExpertRequest;
+use App\Http\Request\SecurityDecisionRequest;
 use Yii;
 use yii\web\Response;
 use yii\web\ConflictHttpException;
@@ -551,27 +553,22 @@ final class RequestController extends ApiController
     /** @return array<string, mixed> */
     public function actionSecurityDecision(int $id): array
     {
-        $input = new SecurityDecisionInput();
+        $input = new SecurityDecisionRequest();
         if (($errors = $this->bodyValidationErrors($input)) !== null) {
             return $errors;
         }
 
         $actorId = $this->currentUserId();
+        $command = $input->toCommand($id, $actorId);
         try {
-            return $this->repository()->decideSecurity(
-                $id,
-                $actorId,
-                (string) $input->decision,
-                $input->reason === '' ? null : (string) $input->reason,
-                (int) $input->lockVersion,
-            );
+            return Yii::$container->get(DecideSecurity::class)->execute($command)->toArray();
         } catch (RequestNotFound $error) {
             throw new NotFoundHttpException($error->getMessage());
         } catch (SecurityDecisionDenied $error) {
-            $this->recordRejectedSecurityDecisionSafely($id, $actorId, $error->ruleId);
+            $this->recordRejectedSecurityDecisionSafely($command, $error->ruleId);
             throw new ForbiddenHttpException($error->getMessage());
         } catch (ConcurrentRequestModification $error) {
-            $this->recordRejectedSecurityDecisionSafely($id, $actorId, $error->ruleId);
+            $this->recordRejectedSecurityDecisionSafely($command, $error->ruleId);
             throw new ConflictHttpException($error->getMessage());
         }
     }
@@ -809,12 +806,12 @@ final class RequestController extends ApiController
         );
     }
 
-    private function recordRejectedSecurityDecisionSafely(int $requestId, int $actorId, string $ruleId): void
+    private function recordRejectedSecurityDecisionSafely(DecideSecurityCommand $command, string $ruleId): void
     {
         $this->recordRejectedSafely(
-            fn () => $this->repository()->recordRejectedSecurityDecision($requestId, $actorId, $ruleId),
+            fn () => Yii::$container->get(DecideSecurity::class)->recordRejected($command, $ruleId),
             'Не удалось записать аудит отклонённого решения СБ.',
-            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            ['requestId' => $command->requestId, 'actorId' => $command->actorId, 'ruleId' => $ruleId],
             __METHOD__,
         );
     }

--- a/backend/src/Http/Request/SecurityDecisionRequest.php
+++ b/backend/src/Http/Request/SecurityDecisionRequest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace App\Application\Request;
+namespace App\Http\Request;
 
+use App\Application\Request\Command\DecideSecurityCommand;
 use yii\base\Model;
 
-final class SecurityDecisionInput extends Model
+final class SecurityDecisionRequest extends Model
 {
     public mixed $decision = null;
     public mixed $reason = null;
@@ -23,5 +24,16 @@ final class SecurityDecisionInput extends Model
             ['lockVersion', 'required'],
             ['lockVersion', 'integer', 'min' => 1],
         ];
+    }
+
+    public function toCommand(int $requestId, int $actorId): DecideSecurityCommand
+    {
+        return new DecideSecurityCommand(
+            $requestId,
+            $actorId,
+            (string) $this->decision,
+            $this->reason === null || $this->reason === '' ? null : (string) $this->reason,
+            (int) $this->lockVersion,
+        );
     }
 }

--- a/backend/src/Infrastructure/Persistence/Request/SecurityDecisionPersistenceAdapter.php
+++ b/backend/src/Infrastructure/Persistence/Request/SecurityDecisionPersistenceAdapter.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Request;
+
+use App\Application\Request\Port\SecurityDecisionGateway;
+use App\Application\Request\SecurityDecisionSnapshot;
+use App\Domain\Request\RequestStatus;
+use App\Domain\Request\Role;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Notification\NotificationOutbox;
+use yii\db\Connection;
+
+final readonly class SecurityDecisionPersistenceAdapter implements SecurityDecisionGateway
+{
+    public function __construct(private Connection $db)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        $transaction = $this->db->beginTransaction();
+        try {
+            $result = $operation();
+            $transaction->commit();
+            return $result;
+        } catch (\Throwable $error) {
+            $transaction->rollBack();
+            throw $error;
+        }
+    }
+
+    public function decisionSnapshotForUpdate(int $requestId, int $actorId): ?SecurityDecisionSnapshot
+    {
+        $row = $this->db->createCommand(
+            'SELECT r.status, r.lock_version AS lockVersion, actor.is_active AS actorIsActive, '
+            . "GROUP_CONCAT(DISTINCT role.code ORDER BY role.code SEPARATOR ',') AS roleCodes "
+            . 'FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id '
+            . 'LEFT JOIN {{%user_roles}} ur ON ur.user_id = actor.id '
+            . 'LEFT JOIN {{%roles}} role ON role.id = ur.role_id '
+            . 'WHERE r.id = :request_id GROUP BY r.id, actor.id FOR UPDATE',
+            [':request_id' => $requestId, ':actor_id' => $actorId],
+        )->queryOne();
+        if ($row === false) {
+            return null;
+        }
+        $roles = array_map(
+            static fn (string $role): Role => Role::from($role),
+            array_filter(explode(',', (string) $row['roleCodes'])),
+        );
+
+        return new SecurityDecisionSnapshot(
+            RequestStatus::from((string) $row['status']),
+            (int) $row['lockVersion'],
+            (bool) $row['actorIsActive'],
+            $roles,
+        );
+    }
+
+    public function currentUncheckedOpinionIdForUpdate(int $requestId): ?int
+    {
+        $opinionId = $this->db->createCommand(
+            'SELECT eo.id FROM {{%expert_opinions}} eo '
+            . 'LEFT JOIN {{%security_checks}} sc ON sc.expert_opinion_id = eo.id '
+            . 'WHERE eo.request_id = :request_id AND sc.id IS NULL '
+            . 'ORDER BY eo.revision DESC LIMIT 1 FOR UPDATE',
+            [':request_id' => $requestId],
+        )->queryScalar();
+
+        return $opinionId === false ? null : (int) $opinionId;
+    }
+
+    public function recordSecurityCheck(
+        int $requestId,
+        int $opinionId,
+        int $actorId,
+        string $decision,
+        ?string $reason,
+        string $decidedAt,
+    ): void {
+        $this->db->createCommand()->insert('{{%security_checks}}', [
+            'request_id' => $requestId,
+            'expert_opinion_id' => $opinionId,
+            'officer_id' => $actorId,
+            'decision' => $decision,
+            'reason' => $reason,
+            'created_at' => $decidedAt,
+        ])->execute();
+    }
+
+    public function persistDecision(
+        int $requestId,
+        RequestStatus $targetStatus,
+        int $expectedLockVersion,
+        int $nextLockVersion,
+        string $decidedAt,
+    ): bool {
+        return $this->db->createCommand()->update('{{%requests}}', [
+            'status' => $targetStatus->value,
+            'lock_version' => $nextLockVersion,
+            'updated_at' => $decidedAt,
+        ], [
+            'id' => $requestId,
+            'status' => RequestStatus::SecurityReview->value,
+            'lock_version' => $expectedLockVersion,
+        ])->execute() === 1;
+    }
+
+    public function recordDecision(
+        int $requestId,
+        int $actorId,
+        string $decision,
+        ?string $reason,
+        RequestStatus $targetStatus,
+        string $decidedAt,
+    ): void {
+        $action = $decision === 'approve' ? 'security_approve' : 'security_return';
+        $ruleId = $decision === 'approve' ? 'SEC-002' : 'SEC-003';
+        $this->db->createCommand()->insert('{{%request_transitions}}', [
+            'request_id' => $requestId,
+            'actor_id' => $actorId,
+            'from_status' => RequestStatus::SecurityReview->value,
+            'to_status' => $targetStatus->value,
+            'action' => $action,
+            'rule_id' => $ruleId,
+            'reason' => $decision === 'return' ? $reason : null,
+            'created_at' => $decidedAt,
+        ])->execute();
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.security_decided',
+            'entity_type' => 'request',
+            'entity_id' => $requestId,
+            'actor_id' => $actorId,
+            'rule_id' => $ruleId,
+            'payload_json' => ['decision' => $decision, 'reason' => $reason],
+            'created_at' => $decidedAt,
+        ])->execute();
+    }
+
+    public function enqueueDecisionNotification(int $requestId, string $decision, ?string $reason): void
+    {
+        $outbox = new NotificationOutbox($this->db);
+        if ($decision === 'approve') {
+            $initiator = $this->initiatorContact($requestId);
+            if ($initiator === null) {
+                return;
+            }
+            $documentLinks = [];
+            $reportVersionId = $this->latestDocumentVersionId($requestId, 'report');
+            if ($reportVersionId !== null) {
+                $documentLinks[] = ['label' => 'отчёт', 'documentVersionId' => $reportVersionId];
+            }
+            $opinionVersionId = $this->latestDocumentVersionId($requestId, 'opinion');
+            if ($opinionVersionId !== null) {
+                $documentLinks[] = ['label' => 'заключение', 'documentVersionId' => $opinionVersionId];
+            }
+            $outbox->enqueue(
+                $requestId,
+                'request.completed',
+                $initiator['email'],
+                $initiator['name'],
+                'Испытания завершены',
+                'Испытания по вашей заявке завершены. Служба безопасности согласовала заключение. '
+                . 'Отчёт и заключение доступны в портале.',
+                $documentLinks,
+            );
+            return;
+        }
+
+        $executor = $this->currentAssigneeContact($requestId, 'executor');
+        if ($executor !== null) {
+            $outbox->enqueue(
+                $requestId,
+                'request.returned',
+                $executor['email'],
+                $executor['name'],
+                'Заявка возвращена на доработку',
+                "Служба безопасности вернула заявку на доработку.\nПричина: {$reason}\n\n"
+                . 'Загрузите исправленный отчёт в портале.',
+            );
+        }
+    }
+
+    public function decisionTimestamp(): string
+    {
+        return Clock::now();
+    }
+
+    public function recordRejectedDecision(int $requestId, int $actorId, string $ruleId): void
+    {
+        $allowedReferences = $this->db->createCommand(
+            'SELECT 1 FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id WHERE r.id = :request_id',
+            [':request_id' => $requestId, ':actor_id' => $actorId],
+        )->queryScalar();
+        if ($allowedReferences === false) {
+            return;
+        }
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.security_decision_rejected',
+            'entity_type' => 'request',
+            'entity_id' => $requestId,
+            'actor_id' => $actorId,
+            'rule_id' => $ruleId,
+            'payload_json' => ['outcome' => 'rejected'],
+            'created_at' => Clock::now(),
+        ])->execute();
+    }
+
+    /** @return array{email: string, name: string}|null */
+    private function initiatorContact(int $requestId): ?array
+    {
+        $row = $this->db->createCommand(
+            'SELECT TRIM(u.email) AS email, u.display_name AS name FROM {{%requests}} r '
+            . 'JOIN {{%users}} u ON u.id = r.initiator_id '
+            . "WHERE r.id = :request_id AND u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != ''",
+            [':request_id' => $requestId],
+        )->queryOne();
+
+        return $row === false ? null : $row;
+    }
+
+    /** @return array{email: string, name: string}|null */
+    private function currentAssigneeContact(int $requestId, string $type): ?array
+    {
+        $row = $this->db->createCommand(
+            'SELECT TRIM(u.email) AS email, u.display_name AS name FROM {{%request_assignments}} a '
+            . 'JOIN {{%users}} u ON u.id = a.user_id '
+            . 'WHERE a.request_id = :request_id AND a.assignment_type = :assignment_type '
+            . "AND a.valid_to IS NULL AND u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != ''",
+            [':request_id' => $requestId, ':assignment_type' => $type],
+        )->queryOne();
+
+        return $row === false ? null : $row;
+    }
+
+    private function latestDocumentVersionId(int $requestId, string $documentType): ?int
+    {
+        $versionId = $this->db->createCommand(
+            'SELECT v.id FROM {{%request_document_versions}} v '
+            . 'JOIN {{%request_documents}} d ON d.id = v.document_id '
+            . 'WHERE d.request_id = :request_id AND d.document_type = :document_type '
+            . 'AND d.deleted_at IS NULL AND v.deleted_at IS NULL '
+            . 'ORDER BY v.version DESC LIMIT 1',
+            [':request_id' => $requestId, ':document_type' => $documentType],
+        )->queryScalar();
+
+        return $versionId === false ? null : (int) $versionId;
+    }
+}

--- a/backend/src/Infrastructure/Request/RequestRepository.php
+++ b/backend/src/Infrastructure/Request/RequestRepository.php
@@ -6,14 +6,11 @@ namespace App\Infrastructure\Request;
 
 use App\Application\Request\CreateRequestInput;
 use App\Domain\Request\CommentPolicy;
-use App\Domain\Request\ConcurrentRequestModification;
 use App\Domain\Request\RequestCreationPolicy;
 use App\Domain\Request\RequestDepartmentMissing;
 use App\Domain\Request\RequestNotFound;
 use App\Domain\Request\RequestStatus;
-use App\Domain\Request\RequestWorkflow;
 use App\Domain\Request\Role;
-use App\Domain\Request\SecurityDecisionPolicy;
 use App\Infrastructure\Clock;
 use App\Infrastructure\Notification\NotificationOutbox;
 use yii\db\Connection;
@@ -128,164 +125,6 @@ final class RequestRepository
             throw $error;
         }
     }
-
-    /** @return array{requestId: int, decision: string, status: string, lockVersion: int} */
-    public function decideSecurity(
-        int $requestId,
-        int $actorId,
-        string $decision,
-        ?string $reason,
-        int $expectedLockVersion,
-    ): array {
-        $transaction = $this->db->beginTransaction();
-        try {
-            $request = $this->db->createCommand(
-                'SELECT r.status, r.lock_version AS lockVersion, actor.is_active AS actorIsActive, '
-                . "GROUP_CONCAT(DISTINCT role.code ORDER BY role.code SEPARATOR ',') AS roleCodes "
-                . 'FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id '
-                . 'LEFT JOIN {{%user_roles}} ur ON ur.user_id = actor.id '
-                . 'LEFT JOIN {{%roles}} role ON role.id = ur.role_id '
-                . 'WHERE r.id = :request_id GROUP BY r.id, actor.id FOR UPDATE',
-                [':request_id' => $requestId, ':actor_id' => $actorId],
-            )->queryOne();
-            if ($request === false) {
-                throw new RequestNotFound('Request not found');
-            }
-            $roles = array_map(
-                static fn (string $role): Role => Role::from($role),
-                array_filter(explode(',', (string) $request['roleCodes'])),
-            );
-            $targetStatus = (new SecurityDecisionPolicy())->targetStatus(
-                RequestStatus::from((string) $request['status']),
-                $decision,
-                $reason,
-                (bool) $request['actorIsActive'],
-                $roles,
-            );
-            if ((int) $request['lockVersion'] !== $expectedLockVersion) {
-                throw new ConcurrentRequestModification();
-            }
-            $opinionId = $this->db->createCommand(
-                'SELECT eo.id FROM {{%expert_opinions}} eo '
-                . 'LEFT JOIN {{%security_checks}} sc ON sc.expert_opinion_id = eo.id '
-                . 'WHERE eo.request_id = :request_id AND sc.id IS NULL '
-                . 'ORDER BY eo.revision DESC LIMIT 1 FOR UPDATE',
-                [':request_id' => $requestId],
-            )->queryScalar();
-            if ($opinionId === false) {
-                throw new \RuntimeException('Current expert opinion not found or already checked.');
-            }
-
-            $now = Clock::now();
-            $this->db->createCommand()->insert('{{%security_checks}}', [
-                'request_id' => $requestId,
-                'expert_opinion_id' => (int) $opinionId,
-                'officer_id' => $actorId,
-                'decision' => $decision,
-                'reason' => $decision === 'return' ? $reason : null,
-                'created_at' => $now,
-            ])->execute();
-            $nextLockVersion = $expectedLockVersion + 1;
-            $updated = $this->db->createCommand()->update('{{%requests}}', [
-                'status' => $targetStatus->value,
-                'lock_version' => $nextLockVersion,
-                'updated_at' => $now,
-            ], [
-                'id' => $requestId,
-                'status' => RequestStatus::SecurityReview->value,
-                'lock_version' => $expectedLockVersion,
-            ])->execute();
-            if ($updated !== 1) {
-                throw new ConcurrentRequestModification();
-            }
-            $action = $decision === 'approve' ? 'security_approve' : 'security_return';
-            $ruleId = $decision === 'approve' ? 'SEC-002' : 'SEC-003';
-            $this->db->createCommand()->insert('{{%request_transitions}}', [
-                'request_id' => $requestId,
-                'actor_id' => $actorId,
-                'from_status' => RequestStatus::SecurityReview->value,
-                'to_status' => $targetStatus->value,
-                'action' => $action,
-                'rule_id' => $ruleId,
-                'reason' => $decision === 'return' ? $reason : null,
-                'created_at' => $now,
-            ])->execute();
-            $this->db->createCommand()->insert('{{%audit_events}}', [
-                'event_type' => 'request.security_decided',
-                'entity_type' => 'request',
-                'entity_id' => $requestId,
-                'actor_id' => $actorId,
-                'rule_id' => $ruleId,
-                'payload_json' => ['decision' => $decision, 'reason' => $reason],
-                'created_at' => $now,
-            ])->execute();
-            $outbox = new NotificationOutbox($this->db);
-            if ($decision === 'approve') {
-                $initiator = $this->initiatorContact($requestId);
-                if ($initiator !== null) {
-                    $documentLinks = [];
-                    $reportVersionId = $this->latestDocumentVersionId($requestId, 'report');
-                    if ($reportVersionId !== null) {
-                        $documentLinks[] = ['label' => 'отчёт', 'documentVersionId' => $reportVersionId];
-                    }
-                    $opinionVersionId = $this->latestDocumentVersionId($requestId, 'opinion');
-                    if ($opinionVersionId !== null) {
-                        $documentLinks[] = ['label' => 'заключение', 'documentVersionId' => $opinionVersionId];
-                    }
-                    $outbox->enqueue(
-                        $requestId,
-                        'request.completed',
-                        $initiator['email'],
-                        $initiator['name'],
-                        'Испытания завершены',
-                        'Испытания по вашей заявке завершены. Служба безопасности согласовала заключение. '
-                        . 'Отчёт и заключение доступны в портале.',
-                        $documentLinks,
-                    );
-                }
-            } else {
-                $executor = $this->currentAssigneeContact($requestId, 'executor');
-                if ($executor !== null) {
-                    $outbox->enqueue(
-                        $requestId,
-                        'request.returned',
-                        $executor['email'],
-                        $executor['name'],
-                        'Заявка возвращена на доработку',
-                        "Служба безопасности вернула заявку на доработку.\nПричина: {$reason}\n\n"
-                        . 'Загрузите исправленный отчёт в портале.',
-                    );
-                }
-            }
-            $transaction->commit();
-
-            return ['requestId' => $requestId, 'decision' => $decision, 'status' => $targetStatus->value, 'lockVersion' => $nextLockVersion];
-        } catch (\Throwable $error) {
-            $transaction->rollBack();
-            throw $error;
-        }
-    }
-
-    public function recordRejectedSecurityDecision(int $requestId, int $actorId, string $ruleId): void
-    {
-        $allowedReferences = $this->db->createCommand(
-            'SELECT 1 FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id WHERE r.id = :request_id',
-            [':request_id' => $requestId, ':actor_id' => $actorId],
-        )->queryScalar();
-        if ($allowedReferences === false) {
-            return;
-        }
-        $this->db->createCommand()->insert('{{%audit_events}}', [
-            'event_type' => 'request.security_decision_rejected',
-            'entity_type' => 'request',
-            'entity_id' => $requestId,
-            'actor_id' => $actorId,
-            'rule_id' => $ruleId,
-            'payload_json' => ['outcome' => 'rejected'],
-            'created_at' => Clock::now(),
-        ])->execute();
-    }
-
 
     /** @return array<string, mixed> */
     public function addComment(int $requestId, int $actorId, string $body): array
@@ -436,20 +275,6 @@ final class RequestRepository
         )->queryAll();
     }
 
-    private function latestDocumentVersionId(int $requestId, string $documentType): ?int
-    {
-        $id = $this->db->createCommand(
-            'SELECT v.id FROM {{%request_document_versions}} v '
-            . 'JOIN {{%request_documents}} d ON d.id = v.document_id '
-            . 'WHERE d.request_id = :request_id AND d.document_type = :document_type '
-            . 'AND d.deleted_at IS NULL AND v.deleted_at IS NULL '
-            . 'ORDER BY v.version DESC LIMIT 1',
-            [':request_id' => $requestId, ':document_type' => $documentType],
-        )->queryScalar();
-
-        return $id === false ? null : (int) $id;
-    }
-
     /** @return array{email: string, name: string}|null */
     private function userContact(int $userId): ?array
     {
@@ -457,33 +282,6 @@ final class RequestRepository
             'SELECT TRIM(email) AS email, display_name AS name FROM {{%users}} '
             . "WHERE id = :id AND is_active = 1 AND email IS NOT NULL AND TRIM(email) != ''",
             [':id' => $userId],
-        )->queryOne();
-
-        return $row === false ? null : $row;
-    }
-
-    /** @return array{email: string, name: string}|null */
-    private function initiatorContact(int $requestId): ?array
-    {
-        $row = $this->db->createCommand(
-            'SELECT TRIM(u.email) AS email, u.display_name AS name FROM {{%requests}} r '
-            . 'JOIN {{%users}} u ON u.id = r.initiator_id '
-            . "WHERE r.id = :request_id AND u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != ''",
-            [':request_id' => $requestId],
-        )->queryOne();
-
-        return $row === false ? null : $row;
-    }
-
-    /** @return array{email: string, name: string}|null */
-    private function currentAssigneeContact(int $requestId, string $assignmentType): ?array
-    {
-        $row = $this->db->createCommand(
-            'SELECT TRIM(u.email) AS email, u.display_name AS name FROM {{%request_assignments}} a '
-            . 'JOIN {{%users}} u ON u.id = a.user_id '
-            . 'WHERE a.request_id = :request_id AND a.assignment_type = :assignment_type '
-            . "AND a.valid_to IS NULL AND u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != ''",
-            [':request_id' => $requestId, ':assignment_type' => $assignmentType],
         )->queryOne();
 
         return $row === false ? null : $row;

--- a/backend/tests/Integration/Http/SecurityDecisionHttpTest.php
+++ b/backend/tests/Integration/Http/SecurityDecisionHttpTest.php
@@ -1,0 +1,155 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Http;
+
+use App\Application\Request\CreateRequestInput;
+use App\Application\Request\Port\SecurityDecisionGateway;
+use App\Http\Controller\RequestController;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter;
+use App\Infrastructure\Request\RequestRepository;
+use Tests\Integration\IntegrationTestCase;
+use Yii;
+use yii\web\Application;
+use yii\web\ConflictHttpException;
+use yii\web\ForbiddenHttpException;
+use yii\web\NotFoundHttpException;
+use yii\web\Request;
+
+final class SecurityDecisionHttpTest extends IntegrationTestCase
+{
+    protected function tearDown(): void
+    {
+        Yii::$app?->errorHandler->unregister();
+        Yii::$app = null;
+        parent::tearDown();
+    }
+
+    public function testApproveKeepsResponseShape(): void
+    {
+        [$requestId, $lockVersion, $officerId] = $this->fixture('approve');
+
+        $response = $this->controller([
+            'decision' => 'approve', 'reason' => null, 'lockVersion' => $lockVersion,
+        ], $officerId)->actionSecurityDecision($requestId);
+
+        self::assertSame(['requestId', 'decision', 'status', 'lockVersion'], array_keys($response));
+        self::assertSame([$requestId, 'approve', 'completed', $lockVersion + 1], array_values($response));
+    }
+
+    public function testReturnRequiresAndTrimsReasonWith422Contract(): void
+    {
+        $invalid = $this->controller([
+            'decision' => 'return', 'reason' => '   ', 'lockVersion' => 1,
+        ], null)->actionSecurityDecision(10);
+        self::assertSame(['reason'], array_keys($invalid['errors']));
+        self::assertSame(422, Yii::$app->response->statusCode);
+
+        [$requestId, $lockVersion, $officerId] = $this->fixture('trim');
+        $this->controller([
+            'decision' => 'return', 'reason' => '  Уточнить вывод  ', 'lockVersion' => $lockVersion,
+        ], $officerId)->actionSecurityDecision($requestId);
+        self::assertSame('Уточнить вывод', $this->scalar(
+            "SELECT reason FROM {{%request_transitions}} WHERE request_id = :id AND action = 'security_return'",
+            [':id' => $requestId],
+        ));
+    }
+
+    public function testMissingDeniedAndStaleKeep404403409ContractsAndDeniedAudit(): void
+    {
+        [$requestId, $lockVersion, $officerId] = $this->fixture('errors');
+        try {
+            $this->controller([
+                'decision' => 'approve', 'lockVersion' => 1,
+            ], $officerId)->actionSecurityDecision(PHP_INT_MAX);
+            self::fail('Expected not found.');
+        } catch (NotFoundHttpException) {
+        }
+
+        $employee = $this->createUser('security.http.errors.employee', 'Сотрудник');
+        try {
+            $this->controller([
+                'decision' => 'approve', 'lockVersion' => $lockVersion,
+            ], $employee)->actionSecurityDecision($requestId);
+            self::fail('Expected forbidden.');
+        } catch (ForbiddenHttpException) {
+            self::assertSame(1, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND actor_id = :actor "
+                . "AND event_type = 'request.security_decision_rejected' AND rule_id = 'SEC-001'",
+                [':id' => $requestId, ':actor' => $employee],
+            ));
+        }
+
+        try {
+            $this->controller([
+                'decision' => 'approve', 'lockVersion' => $lockVersion + 1,
+            ], $officerId)->actionSecurityDecision($requestId);
+            self::fail('Expected conflict.');
+        } catch (ConflictHttpException) {
+            self::assertSame(1, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND actor_id = :actor "
+                . "AND event_type = 'request.security_decision_rejected' AND rule_id = 'WF-003'",
+                [':id' => $requestId, ':actor' => $officerId],
+            ));
+        }
+    }
+
+    /** @return array{int, int, int} */
+    private function fixture(string $marker): array
+    {
+        $initiator = $this->createUser("security.http.{$marker}.initiator", 'Инициатор');
+        $expert = $this->createUser("security.http.{$marker}.expert", 'Эксперт');
+        $officer = $this->createUser("security.http.{$marker}.officer", 'Сотрудник СБ');
+        $this->grantRole($officer, 'security_officer');
+        $input = new CreateRequestInput();
+        $input->setAttributes([
+            'productName' => "HTTP security {$marker}", 'manufacturer' => 'Завод', 'supplier' => 'Поставщик',
+            'sampleQuantity' => 1, 'testMethod' => 'Методика',
+        ]);
+        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $requestId = (int) $request['id'];
+        $this->db()->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
+        $this->db()->createCommand()->insert('{{%request_documents}}', [
+            'request_id' => $requestId, 'document_type' => 'opinion', 'title' => 'opinion.pdf',
+            'created_by' => $expert, 'created_at' => Clock::now(),
+        ])->execute();
+        $documentId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%request_document_versions}}', [
+            'document_id' => $documentId, 'version' => 1, 'storage_key' => str_repeat('c', 64),
+            'original_name' => 'opinion.pdf', 'mime_type' => 'application/pdf', 'size_bytes' => 1,
+            'sha256' => str_repeat('c', 64), 'uploaded_by' => $expert, 'created_at' => Clock::now(),
+        ])->execute();
+        $versionId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%expert_opinions}}', [
+            'request_id' => $requestId, 'revision' => 1, 'expert_id' => $expert,
+            'body' => 'Заключение', 'document_version_id' => $versionId, 'created_at' => Clock::now(),
+        ])->execute();
+        return [$requestId, (int) $request['lock_version'], $officer];
+    }
+
+    /** @param array<string, mixed> $body */
+    private function controller(array $body, ?int $actorId): RequestController
+    {
+        Yii::$app?->errorHandler->unregister();
+        Yii::$app = null;
+        $application = new Application([
+            'id' => 'security-decision-http-test', 'basePath' => dirname(__DIR__, 3),
+            'params' => ['identityHeader' => 'X-Test-User-ID'],
+            'container' => ['definitions' => [
+                SecurityDecisionGateway::class => fn () => new SecurityDecisionPersistenceAdapter($this->db()),
+            ]],
+            'components' => [
+                'db' => $this->db(),
+                'request' => ['class' => Request::class, 'cookieValidationKey' => 'security-http-test'],
+            ],
+        ]);
+        $application->request->headers->set('Content-Type', 'application/json');
+        if ($actorId !== null) {
+            $application->request->headers->set('X-Test-User-ID', (string) $actorId);
+        }
+        $application->request->setRawBody(json_encode((object) $body, JSON_THROW_ON_ERROR));
+        return new RequestController('request', $application);
+    }
+}

--- a/backend/tests/Integration/Request/ControlledSecurityDecisionAuditFailureCommand.php
+++ b/backend/tests/Integration/Request/ControlledSecurityDecisionAuditFailureCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use yii\db\Command;
+
+final class ControlledSecurityDecisionAuditFailureCommand extends Command
+{
+    /** @param array<string, mixed>|\yii\db\Query $columns */
+    public function insert($table, $columns)
+    {
+        if (
+            $table === '{{%audit_events}}'
+            && is_array($columns)
+            && ($columns['event_type'] ?? null) === 'request.security_decided'
+        ) {
+            throw new \RuntimeException('controlled security decision audit failure');
+        }
+        return parent::insert($table, $columns);
+    }
+}

--- a/backend/tests/Integration/Request/SecurityDecisionAtomicityTest.php
+++ b/backend/tests/Integration/Request/SecurityDecisionAtomicityTest.php
@@ -1,0 +1,126 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use App\Application\Request\Command\DecideSecurityCommand;
+use App\Application\Request\CreateRequestInput;
+use App\Application\Request\UseCase\DecideSecurity;
+use App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter;
+use App\Infrastructure\Request\RequestRepository;
+use PHPUnit\Framework\TestCase;
+use yii\db\Connection;
+
+final class SecurityDecisionAtomicityTest extends TestCase
+{
+    public function testMutationCheckAndTransitionRollBackWhenMandatoryAuditFails(): void
+    {
+        $db = $this->connection();
+        $outer = $db->beginTransaction();
+        $marker = bin2hex(random_bytes(6));
+        $now = gmdate('Y-m-d H:i:s');
+        try {
+            $initiator = $this->createUser($db, "security-atomic-initiator-{$marker}", $now);
+            $expert = $this->createUser($db, "security-atomic-expert-{$marker}", $now);
+            $officer = $this->createUser($db, "security-atomic-officer-{$marker}", $now);
+            $this->grantRole($db, $officer, 'security_officer', $now);
+            $input = new CreateRequestInput();
+            $input->setAttributes([
+                'productName' => "Security atomicity {$marker}", 'manufacturer' => 'Завод',
+                'supplier' => 'Поставщик', 'sampleQuantity' => 1, 'testMethod' => 'Методика',
+            ]);
+            $request = (new RequestRepository($db))->create($input, $initiator);
+            $requestId = (int) $request['id'];
+            $db->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
+            $db->createCommand()->insert('{{%request_documents}}', [
+                'request_id' => $requestId, 'document_type' => 'opinion', 'title' => 'opinion.pdf',
+                'created_by' => $expert, 'created_at' => $now,
+            ])->execute();
+            $documentId = (int) $db->getLastInsertID();
+            $db->createCommand()->insert('{{%request_document_versions}}', [
+                'document_id' => $documentId, 'version' => 1, 'storage_key' => str_repeat('d', 64),
+                'original_name' => 'opinion.pdf', 'mime_type' => 'application/pdf', 'size_bytes' => 1,
+                'sha256' => str_repeat('d', 64), 'uploaded_by' => $expert, 'created_at' => $now,
+            ])->execute();
+            $versionId = (int) $db->getLastInsertID();
+            $db->createCommand()->insert('{{%expert_opinions}}', [
+                'request_id' => $requestId, 'revision' => 1, 'expert_id' => $expert,
+                'body' => 'Заключение', 'document_version_id' => $versionId, 'created_at' => $now,
+            ])->execute();
+
+            try {
+                (new DecideSecurity(new SecurityDecisionPersistenceAdapter($db)))->execute(
+                    new DecideSecurityCommand(
+                        $requestId,
+                        $officer,
+                        'approve',
+                        null,
+                        (int) $request['lock_version'],
+                    ),
+                );
+                self::fail('Expected controlled audit failure.');
+            } catch (\RuntimeException $error) {
+                self::assertStringContainsString('controlled security decision audit failure', $error->getMessage());
+            }
+
+            $row = $db->createCommand(
+                'SELECT status, lock_version FROM {{%requests}} WHERE id = :id',
+                [':id' => $requestId],
+            )->queryOne();
+            self::assertSame('security_review', (string) $row['status']);
+            self::assertSame((int) $request['lock_version'], (int) $row['lock_version']);
+            self::assertSame(0, (int) $db->createCommand(
+                'SELECT COUNT(*) FROM {{%security_checks}} WHERE request_id = :id',
+                [':id' => $requestId],
+            )->queryScalar());
+            self::assertSame(0, (int) $db->createCommand(
+                "SELECT COUNT(*) FROM {{%request_transitions}} WHERE request_id = :id AND action = 'security_approve'",
+                [':id' => $requestId],
+            )->queryScalar());
+            self::assertSame(0, (int) $db->createCommand(
+                "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id AND event_type = 'request.completed'",
+                [':id' => $requestId],
+            )->queryScalar());
+        } finally {
+            if ($outer->isActive) {
+                $outer->rollBack();
+            }
+            $db->close();
+        }
+    }
+
+    private function createUser(Connection $db, string $login, string $now): int
+    {
+        $db->createCommand()->insert('{{%users}}', [
+            'ad_login' => $login, 'display_name' => $login, 'email' => "{$login}@example.invalid",
+            'department' => 'Тестовое подразделение', 'is_active' => 1,
+            'created_at' => $now, 'updated_at' => $now,
+        ])->execute();
+        return (int) $db->getLastInsertID();
+    }
+
+    private function grantRole(Connection $db, int $userId, string $role, string $now): void
+    {
+        $roleId = $db->createCommand('SELECT id FROM {{%roles}} WHERE code = :code', [':code' => $role])->queryScalar();
+        $db->createCommand()->insert('{{%user_roles}}', [
+            'user_id' => $userId, 'role_id' => $roleId, 'created_at' => $now,
+        ])->execute();
+    }
+
+    private function connection(): Connection
+    {
+        $connection = new Connection([
+            'dsn' => sprintf(
+                'mysql:host=%s;port=%s;dbname=%s',
+                getenv('DB_HOST') ?: '127.0.0.1',
+                getenv('DB_PORT') ?: '3306',
+                getenv('DB_NAME') ?: 'ic_test'
+            ),
+            'username' => getenv('DB_USER') ?: 'ic', 'password' => getenv('DB_PASSWORD') ?: '',
+            'charset' => 'utf8mb4', 'commandClass' => ControlledSecurityDecisionAuditFailureCommand::class,
+        ]);
+        $connection->open();
+        return $connection;
+    }
+}

--- a/backend/tests/Integration/Request/SecurityDecisionTest.php
+++ b/backend/tests/Integration/Request/SecurityDecisionTest.php
@@ -1,0 +1,247 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use App\Application\Request\Command\DecideSecurityCommand;
+use App\Application\Request\CreateRequestInput;
+use App\Application\Request\UseCase\DecideSecurity;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\RequestNotFound;
+use App\Domain\Request\SecurityDecisionDenied;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter;
+use App\Infrastructure\Request\RequestRepository;
+use Tests\Integration\IntegrationTestCase;
+
+final class SecurityDecisionTest extends IntegrationTestCase
+{
+    public function testApproveCompletesRequestAndRecordsAllEffectsAndDocumentLinks(): void
+    {
+        $fixture = $this->fixture('approve');
+        $result = $this->decide($fixture, 'approve');
+
+        self::assertSame($fixture['requestId'], $result['requestId']);
+        self::assertSame('approve', $result['decision']);
+        self::assertSame('completed', $result['status']);
+        self::assertSame((int) $fixture['lockVersion'] + 1, $result['lockVersion']);
+        self::assertSame('security_approve', $this->scalar(
+            'SELECT action FROM {{%request_transitions}} WHERE request_id = :id ORDER BY id DESC LIMIT 1',
+            [':id' => $fixture['requestId']],
+        ));
+        self::assertSame('SEC-002', $this->scalar(
+            "SELECT rule_id FROM {{%audit_events}} WHERE entity_id = :id AND event_type = 'request.security_decided'",
+            [':id' => $fixture['requestId']],
+        ));
+        $notification = $this->db()->createCommand(
+            "SELECT event_type, recipient_email, subject, body, payload_json FROM {{%notification_outbox}} "
+            . "WHERE request_id = :id AND event_type = 'request.completed'",
+            [':id' => $fixture['requestId']],
+        )->queryOne();
+        self::assertSame($fixture['initiatorEmail'], $notification['recipient_email']);
+        self::assertSame('Испытания завершены', $notification['subject']);
+        self::assertStringContainsString('Служба безопасности согласовала заключение', $notification['body']);
+        $payload = is_array($notification['payload_json'])
+            ? $notification['payload_json']
+            : json_decode((string) $notification['payload_json'], true, flags: JSON_THROW_ON_ERROR);
+        self::assertSame([
+            ['label' => 'отчёт', 'documentVersionId' => $fixture['reportVersionId']],
+            ['label' => 'заключение', 'documentVersionId' => $fixture['opinionVersionId']],
+        ], $payload['documentLinks']);
+    }
+
+    public function testReturnRestoresInProgressAndNotifiesOnlyExecutorWithReason(): void
+    {
+        $fixture = $this->fixture('return');
+        $result = $this->decide($fixture, 'return', '  Уточнить вывод  ');
+
+        self::assertSame('in_progress', $result['status']);
+        self::assertSame('  Уточнить вывод  ', $this->scalar(
+            "SELECT reason FROM {{%request_transitions}} WHERE request_id = :id AND action = 'security_return'",
+            [':id' => $fixture['requestId']],
+        ));
+        $notification = $this->db()->createCommand(
+            'SELECT event_type, recipient_email, subject, body FROM {{%notification_outbox}} '
+            . 'WHERE request_id = :id ORDER BY id DESC LIMIT 1',
+            [':id' => $fixture['requestId']],
+        )->queryOne();
+        self::assertSame('request.returned', $notification['event_type']);
+        self::assertSame($fixture['executorEmail'], $notification['recipient_email']);
+        self::assertSame('Заявка возвращена на доработку', $notification['subject']);
+        self::assertStringContainsString('Причина:   Уточнить вывод  ', $notification['body']);
+        self::assertSame(0, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id AND event_type = 'request.completed'",
+            [':id' => $fixture['requestId']],
+        ));
+    }
+
+    public function testAuthorizationActiveRoleInvalidStatusAndStaleVersionKeepRuleSemantics(): void
+    {
+        $fixture = $this->fixture('denials');
+        $cases = [
+            [$this->createUser('security.denials.employee', 'Сотрудник'), true, 'SEC-001'],
+            [$this->inactiveOfficer('security.denials.inactive'), true, 'AUTH-003'],
+            [$fixture['officerId'], false, 'SEC-001'],
+        ];
+        foreach ($cases as [$actorId, $securityStatus, $ruleId]) {
+            $this->db()->createCommand()->update('{{%requests}}', [
+                'status' => $securityStatus ? 'security_review' : 'in_progress',
+            ], ['id' => $fixture['requestId']])->execute();
+            try {
+                $this->useCase()->execute(new DecideSecurityCommand(
+                    $fixture['requestId'],
+                    $actorId,
+                    'approve',
+                    null,
+                    $fixture['lockVersion'],
+                ));
+                self::fail('Expected denied security decision.');
+            } catch (SecurityDecisionDenied $error) {
+                self::assertSame($ruleId, $error->ruleId);
+            }
+        }
+
+        $this->db()->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $fixture['requestId']])->execute();
+        $this->expectException(ConcurrentRequestModification::class);
+        $this->useCase()->execute(new DecideSecurityCommand(
+            $fixture['requestId'],
+            $fixture['officerId'],
+            'approve',
+            null,
+            $fixture['lockVersion'] + 1,
+        ));
+    }
+
+    public function testMissingRequestAndLockedOpinionStateRemainDistinct(): void
+    {
+        $fixture = $this->fixture('missing-opinion');
+        try {
+            $this->useCase()->execute(new DecideSecurityCommand(
+                PHP_INT_MAX,
+                $fixture['officerId'],
+                'approve',
+                null,
+                1,
+            ));
+            self::fail('Expected missing request.');
+        } catch (RequestNotFound) {
+        }
+
+        $this->db()->createCommand()->insert('{{%security_checks}}', [
+            'request_id' => $fixture['requestId'],
+            'expert_opinion_id' => $fixture['opinionId'],
+            'officer_id' => $fixture['officerId'],
+            'decision' => 'return',
+            'reason' => 'Предыдущая проверка',
+            'created_at' => Clock::now(),
+        ])->execute();
+        $this->expectExceptionMessage('Current expert opinion not found or already checked.');
+        $this->decide($fixture, 'approve');
+    }
+
+    public function testRejectedAuditKeepsExistingReferenceSemantics(): void
+    {
+        $fixture = $this->fixture('rejected-audit');
+        $useCase = $this->useCase();
+        $command = new DecideSecurityCommand(
+            $fixture['requestId'],
+            $fixture['officerId'],
+            'approve',
+            null,
+            $fixture['lockVersion'],
+        );
+        $useCase->recordRejected($command, 'SEC-001');
+        $useCase->recordRejected(new DecideSecurityCommand(
+            PHP_INT_MAX,
+            $fixture['officerId'],
+            'approve',
+            null,
+            1,
+        ), 'SEC-001');
+
+        self::assertSame(1, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id "
+            . "AND event_type = 'request.security_decision_rejected' AND rule_id = 'SEC-001'",
+            [':id' => $fixture['requestId']],
+        ));
+    }
+
+    /**
+     * @param array<string, int|string> $fixture
+     * @return array{requestId: int, decision: string, status: string, lockVersion: int}
+     */
+    private function decide(array $fixture, string $decision, ?string $reason = null): array
+    {
+        return $this->useCase()->execute(new DecideSecurityCommand(
+            (int) $fixture['requestId'],
+            (int) $fixture['officerId'],
+            $decision,
+            $reason,
+            (int) $fixture['lockVersion'],
+        ))->toArray();
+    }
+
+    private function useCase(): DecideSecurity
+    {
+        return new DecideSecurity(new SecurityDecisionPersistenceAdapter($this->db()));
+    }
+
+    private function inactiveOfficer(string $login): int
+    {
+        $id = $this->createUser($login, 'Неактивный сотрудник СБ', isActive: false);
+        $this->grantRole($id, 'security_officer');
+        return $id;
+    }
+
+    /** @return array<string, int|string> */
+    private function fixture(string $marker): array
+    {
+        $initiatorEmail = "security.{$marker}.initiator@example.invalid";
+        $executorEmail = "security.{$marker}.executor@example.invalid";
+        $initiator = $this->createUser("security.{$marker}.initiator", 'Инициатор', $initiatorEmail);
+        $executor = $this->createUser("security.{$marker}.executor", 'Исполнитель', $executorEmail);
+        $expert = $this->createUser("security.{$marker}.expert", 'Эксперт');
+        $officer = $this->createUser("security.{$marker}.officer", 'Сотрудник СБ');
+        $this->grantRole($officer, 'security_officer');
+        $input = new CreateRequestInput();
+        $input->setAttributes([
+            'productName' => "Security {$marker}", 'manufacturer' => 'Завод', 'supplier' => 'Поставщик',
+            'sampleQuantity' => 1, 'testMethod' => 'Методика',
+        ]);
+        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $requestId = (int) $request['id'];
+        $this->db()->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
+        $this->db()->createCommand()->insert('{{%request_assignments}}', [
+            'request_id' => $requestId, 'assignment_type' => 'executor', 'user_id' => $executor,
+            'assigned_by' => $officer, 'valid_from' => Clock::now(),
+        ])->execute();
+        $reportVersionId = $this->documentVersion($requestId, $executor, 'report', 'report.pdf', 'a');
+        $opinionVersionId = $this->documentVersion($requestId, $expert, 'opinion', 'opinion.pdf', 'b');
+        $this->db()->createCommand()->insert('{{%expert_opinions}}', [
+            'request_id' => $requestId, 'revision' => 1, 'expert_id' => $expert,
+            'body' => 'Заключение', 'document_version_id' => $opinionVersionId, 'created_at' => Clock::now(),
+        ])->execute();
+
+        return [
+            'requestId' => $requestId, 'lockVersion' => (int) $request['lock_version'], 'officerId' => $officer,
+            'opinionId' => (int) $this->db()->getLastInsertID(), 'reportVersionId' => $reportVersionId,
+            'opinionVersionId' => $opinionVersionId, 'initiatorEmail' => $initiatorEmail, 'executorEmail' => $executorEmail,
+        ];
+    }
+
+    private function documentVersion(int $requestId, int $actorId, string $type, string $name, string $key): int
+    {
+        $this->db()->createCommand()->insert('{{%request_documents}}', [
+            'request_id' => $requestId, 'document_type' => $type, 'title' => $name,
+            'created_by' => $actorId, 'created_at' => Clock::now(),
+        ])->execute();
+        $documentId = (int) $this->db()->getLastInsertID();
+        $this->db()->createCommand()->insert('{{%request_document_versions}}', [
+            'document_id' => $documentId, 'version' => 1, 'storage_key' => str_repeat($key, 64),
+            'original_name' => $name, 'mime_type' => 'application/pdf', 'size_bytes' => 1,
+            'sha256' => str_repeat($key, 64), 'uploaded_by' => $actorId, 'created_at' => Clock::now(),
+        ])->execute();
+        return (int) $this->db()->getLastInsertID();
+    }
+}

--- a/backend/tests/Unit/Http/Request/SecurityDecisionRequestTest.php
+++ b/backend/tests/Unit/Http/Request/SecurityDecisionRequestTest.php
@@ -2,25 +2,36 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Application\Request;
+namespace Tests\Unit\Http\Request;
 
-use App\Application\Request\SecurityDecisionInput;
+use App\Http\Request\SecurityDecisionRequest;
 use PHPUnit\Framework\TestCase;
 
-final class SecurityDecisionInputTest extends TestCase
+final class SecurityDecisionRequestTest extends TestCase
 {
     public function testValidDecisions(): void
     {
         foreach ([['approve', null], ['return', 'Нужны повторные испытания']] as [$decision, $reason]) {
-            $input = new SecurityDecisionInput();
+            $input = new SecurityDecisionRequest();
             $input->load(['decision' => $decision, 'reason' => $reason, 'lockVersion' => 6], '');
             self::assertTrue($input->validate());
         }
     }
 
+    public function testCommandPreservesNullReasonAndCastsVersion(): void
+    {
+        $input = new SecurityDecisionRequest();
+        $input->load(['decision' => 'approve', 'reason' => null, 'lockVersion' => '6'], '');
+        self::assertTrue($input->validate());
+
+        $command = $input->toCommand(10, 20);
+        self::assertNull($command->reason);
+        self::assertSame(6, $command->expectedLockVersion);
+    }
+
     public function testReturnRequiresReasonAndVersion(): void
     {
-        $input = new SecurityDecisionInput();
+        $input = new SecurityDecisionRequest();
         $input->load(['decision' => 'return', 'reason' => '   ', 'lockVersion' => 0], '');
         self::assertFalse($input->validate());
         self::assertArrayHasKey('reason', $input->errors);
@@ -30,7 +41,7 @@ final class SecurityDecisionInputTest extends TestCase
     public function testStructuredReasonIsRejectedWithoutConversion(): void
     {
         foreach ([['не строка'], (object) ['reason' => 'не строка']] as $reason) {
-            $input = new SecurityDecisionInput();
+            $input = new SecurityDecisionRequest();
             $input->load(['decision' => 'return', 'reason' => $reason, 'lockVersion' => 6], '');
 
             self::assertFalse($input->validate());
@@ -41,7 +52,7 @@ final class SecurityDecisionInputTest extends TestCase
 
     public function testStringReasonIsTrimmed(): void
     {
-        $input = new SecurityDecisionInput();
+        $input = new SecurityDecisionRequest();
         $input->load(['decision' => 'return', 'reason' => '  Уточнить вывод  ', 'lockVersion' => 6], '');
 
         self::assertTrue($input->validate());

--- a/backend/tools/architecture-baseline.php
+++ b/backend/tools/architecture-baseline.php
@@ -20,7 +20,6 @@ return [
         'backend/src/Application/Request/CreateRequestInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/ListRequestsInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/PublishOpinionInput.php' => ['yii\\base\\Model'],
-        'backend/src/Application/Request/SecurityDecisionInput.php' => ['yii\\base\\Model'],
         'backend/src/Http/Controller/AdminController.php' => [
             'App\\Infrastructure\\Admin\\AuditQuery',
             'App\\Infrastructure\\Admin\\NotificationQuery',
@@ -74,10 +73,9 @@ return [
         ],
     ],
     'files' => [
-        'backend/src/Http/Controller/RequestController.php' => 871,
+        'backend/src/Http/Controller/RequestController.php' => 868,
         'backend/src/Infrastructure/Document/DocumentRepository.php' => 782,
         'backend/src/Infrastructure/Request/RequestQuery.php' => 646,
-        'backend/src/Infrastructure/Request/RequestRepository.php' => 519,
         'frontend/src/components/RequestDetails.vue' => 1272,
         'frontend/src/components/RequestRegistry.vue' => 847,
     ],
@@ -108,7 +106,6 @@ return [
         ],
         'backend/src/Infrastructure/Request/RequestRepository.php' => [
             'RequestRepository::create' => 103,
-            'RequestRepository::decideSecurity' => 131,
         ],
     ],
 ];


### PR DESCRIPTION
## Summary

- Removed `decideSecurity` and denied-audit orchestration for this scenario from `RequestRepository`.
- Added the path `SecurityDecisionRequest → DecideSecurityCommand → DecideSecurity → SecurityDecisionPolicy → SecurityDecisionGateway → SecurityDecisionPersistenceAdapter`.
- Removed Yii `SecurityDecisionInput` from Application and moved validation to Http.
- Preserved authorization, `security_review`, reason semantics, request/opinion locking, optimistic concurrency, transitions, audit, outbox, report/opinion document links, and the HTTP response/error contract.
- Historical quirks were intentionally not corrected; business, HTTP, and concurrency behavior remains unchanged.

## Metrics

- `RequestRepository`: 519 → 317 LOC
- `RequestController`: 871 → 868 LOC
- Forbidden dependency exceptions: 19 → 18
- Oversized files: 6 → 5
- Oversized methods: 12 → 11
- Production net LOC: +268
- Test net LOC: +552

## Validation

- `make check` — PASS
- `make e2e` — PASS
- `make coverage` — PASS
- Backend Domain/Application coverage: 95.45%
- `$pr-review` — no actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a complete workflow for approving or returning security-review requests.
  - Decisions now update request status, record audit history, and send relevant notifications.
  - Return decisions require a reason, with whitespace trimmed automatically.

- **Bug Fixes**
  - Improved handling of missing requests, unauthorized actions, locked reviews, and outdated request versions with consistent error responses.
  - Ensured failed decision processing rolls back all related updates to prevent partial changes.
  - Preserved consistent HTTP response formats for successful and rejected decisions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->