### PR TITLE
Wave 10: вынести создание заявки из RequestRepository

### DIFF
--- a/backend/config/common.php
+++ b/backend/config/common.php
@@ -27,6 +27,8 @@ return [
                 new App\Infrastructure\Persistence\Request\ExpertAssignmentPersistenceAdapter(Yii::$app->db),
             App\Application\Request\Port\SecurityDecisionGateway::class => static fn () =>
                 new App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter(Yii::$app->db),
+            App\Application\Request\Port\RequestCreationGateway::class => static fn () =>
+                new App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter(Yii::$app->db),
         ],
     ],
     'components' => [

--- a/backend/src/Application/Request/Command/CreateRequestCommand.php
+++ b/backend/src/Application/Request/Command/CreateRequestCommand.php
@@ -1,0 +1,18 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Command;
+
+final readonly class CreateRequestCommand
+{
+    public function __construct(
+        public int $initiatorId,
+        public string $productName,
+        public string $manufacturer,
+        public string $supplier,
+        public int $sampleQuantity,
+        public string $testMethod,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/CreateRequestResult.php
+++ b/backend/src/Application/Request/CreateRequestResult.php
@@ -1,0 +1,19 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+final readonly class CreateRequestResult
+{
+    /** @param array<string, mixed> $request */
+    public function __construct(private array $request)
+    {
+    }
+
+    /** @return array<string, mixed> */
+    public function toArray(): array
+    {
+        return $this->request;
+    }
+}

--- a/backend/src/Application/Request/CreationContext.php
+++ b/backend/src/Application/Request/CreationContext.php
@@ -1,0 +1,17 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+use App\Domain\Request\Role;
+
+final readonly class CreationContext
+{
+    /** @param list<Role> $initiatorRoles */
+    public function __construct(
+        public array $initiatorRoles,
+        public bool $initiatorActive,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/Port/RequestCreationGateway.php
+++ b/backend/src/Application/Request/Port/RequestCreationGateway.php
@@ -1,0 +1,42 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Port;
+
+use App\Application\Request\Command\CreateRequestCommand;
+use App\Application\Request\CreationContext;
+
+interface RequestCreationGateway
+{
+    /**
+     * @template T
+     * @param callable(): T $operation
+     * @return T
+     */
+    public function transactional(callable $operation): mixed;
+
+    public function creationContext(int $initiatorId): CreationContext;
+
+    public function departmentSnapshotForUpdate(int $initiatorId): ?string;
+
+    public function allocateNumber(): int;
+
+    public function creationTimestamp(): string;
+
+    public function insertRequest(
+        CreateRequestCommand $command,
+        string $department,
+        int $number,
+        string $createdAt,
+    ): int;
+
+    public function recordCreation(int $requestId, int $actorId, string $createdAt): void;
+
+    public function enqueueCreationNotifications(int $requestId, int $number, string $productName, int $initiatorId): void;
+
+    /** @return array<string, mixed> */
+    public function createdRequest(int $requestId): array;
+
+    public function recordRejectedCreation(int $actorId, string $ruleId): void;
+}

--- a/backend/src/Application/Request/UseCase/CreateRequest.php
+++ b/backend/src/Application/Request/UseCase/CreateRequest.php
@@ -1,0 +1,52 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\UseCase;
+
+use App\Application\Request\Command\CreateRequestCommand;
+use App\Application\Request\CreateRequestResult;
+use App\Application\Request\Port\RequestCreationGateway;
+use App\Domain\Request\RequestCreationPolicy;
+use App\Domain\Request\RequestDepartmentMissing;
+
+final readonly class CreateRequest
+{
+    public function __construct(
+        private RequestCreationGateway $gateway,
+        private RequestCreationPolicy $policy = new RequestCreationPolicy(),
+    ) {
+    }
+
+    public function execute(CreateRequestCommand $command): CreateRequestResult
+    {
+        return $this->gateway->transactional(function () use ($command): CreateRequestResult {
+            $context = $this->gateway->creationContext($command->initiatorId);
+            $this->policy->assertCanCreate($context->initiatorRoles, $context->initiatorActive);
+            $department = $this->gateway->departmentSnapshotForUpdate($command->initiatorId);
+            if ($department === null) {
+                throw new RequestDepartmentMissing(
+                    'В профиле пользователя не указано подразделение. Обратитесь к администратору.',
+                );
+            }
+
+            $number = $this->gateway->allocateNumber();
+            $createdAt = $this->gateway->creationTimestamp();
+            $requestId = $this->gateway->insertRequest($command, $department, $number, $createdAt);
+            $this->gateway->recordCreation($requestId, $command->initiatorId, $createdAt);
+            $this->gateway->enqueueCreationNotifications(
+                $requestId,
+                $number,
+                $command->productName,
+                $command->initiatorId,
+            );
+
+            return new CreateRequestResult($this->gateway->createdRequest($requestId));
+        });
+    }
+
+    public function recordRejected(CreateRequestCommand $command, string $ruleId): void
+    {
+        $this->gateway->recordRejectedCreation($command->initiatorId, $ruleId);
+    }
+}

--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -7,7 +7,6 @@ namespace App\Http\Controller;
 use App\Application\Document\TestActDocumentService;
 use App\Application\Document\TestActConfigurationError;
 use App\Application\Document\TestActInput;
-use App\Application\Request\CreateRequestInput;
 use App\Application\Request\Command\RequestLifecycleCommand;
 use App\Application\Request\UseCase\ChangeRequestDepartment;
 use App\Application\Request\ListRequestsInput;
@@ -18,6 +17,7 @@ use App\Application\Request\Command\CancelRequestCommand;
 use App\Application\Request\Command\DecideSecurityCommand;
 use App\Application\Request\PublishOpinionInput;
 use App\Application\Request\UseCase\DecideSecurity;
+use App\Application\Request\UseCase\CreateRequest as CreateRequestUseCase;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Application\Request\UseCase\RequestLifecycle;
 use App\Application\Request\UseCase\CancelRequest as CancelRequestUseCase;
@@ -60,6 +60,7 @@ use App\Http\Request\CancelRequest;
 use App\Http\Request\AssignExecutorRequest;
 use App\Http\Request\AssignExpertRequest;
 use App\Http\Request\SecurityDecisionRequest;
+use App\Http\Request\CreateRequest;
 use Yii;
 use yii\web\Response;
 use yii\web\ConflictHttpException;
@@ -394,16 +395,16 @@ final class RequestController extends ApiController
     /** @return array<string, mixed> */
     public function actionCreate(): array
     {
-        $input = new CreateRequestInput();
+        $input = new CreateRequest();
         if (($errors = $this->bodyValidationErrors($input)) !== null) {
             return $errors;
         }
 
-        $actorId = $this->currentUserId();
+        $command = $input->toCommand($this->currentUserId());
         try {
-            $request = $this->repository()->create($input, $actorId);
+            $request = Yii::$container->get(CreateRequestUseCase::class)->execute($command)->toArray();
         } catch (RequestCreationDenied $error) {
-            $this->recordRejectedCreateSafely($actorId, $error->ruleId);
+            $this->recordRejectedCreateSafely($command, $error->ruleId);
             throw new ForbiddenHttpException($error->getMessage());
         } catch (RequestDepartmentMissing $error) {
             throw new UnprocessableEntityHttpException($error->getMessage());
@@ -412,7 +413,6 @@ final class RequestController extends ApiController
         Yii::$app->response->headers->set('Location', '/api/v1/requests/' . $request['id']);
         return $request;
     }
-
     /** @return array<string, mixed> */
     public function actionChangeDepartment(int $id): array
     {
@@ -684,12 +684,12 @@ final class RequestController extends ApiController
         }
     }
 
-    private function recordRejectedCreateSafely(int $actorId, string $ruleId): void
+    private function recordRejectedCreateSafely(\App\Application\Request\Command\CreateRequestCommand $command, string $ruleId): void
     {
         $this->recordRejectedSafely(
-            fn () => $this->repository()->recordRejectedCreate($actorId, $ruleId),
+            fn () => Yii::$container->get(CreateRequestUseCase::class)->recordRejected($command, $ruleId),
             'Не удалось записать аудит отклонённого создания заявки.',
-            ['actorId' => $actorId, 'ruleId' => $ruleId],
+            ['actorId' => $command->initiatorId, 'ruleId' => $ruleId],
             __METHOD__,
         );
     }

--- a/backend/src/Http/Request/CreateRequest.php
+++ b/backend/src/Http/Request/CreateRequest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace App\Application\Request;
+namespace App\Http\Request;
 
+use App\Application\Request\Command\CreateRequestCommand;
 use yii\base\Model;
 
-final class CreateRequestInput extends Model
+final class CreateRequest extends Model
 {
     public ?string $productName = null;
     public ?string $manufacturer = null;
@@ -22,5 +23,17 @@ final class CreateRequestInput extends Model
             ['testMethod', 'string', 'max' => 10000],
             ['sampleQuantity', 'integer', 'min' => 1],
         ];
+    }
+
+    public function toCommand(int $initiatorId): CreateRequestCommand
+    {
+        return new CreateRequestCommand(
+            $initiatorId,
+            (string) $this->productName,
+            (string) $this->manufacturer,
+            (string) $this->supplier,
+            (int) $this->sampleQuantity,
+            (string) $this->testMethod,
+        );
     }
 }

--- a/backend/src/Infrastructure/Persistence/Request/RequestCreationPersistenceAdapter.php
+++ b/backend/src/Infrastructure/Persistence/Request/RequestCreationPersistenceAdapter.php
@@ -1,0 +1,221 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Request;
+
+use App\Application\Request\Command\CreateRequestCommand;
+use App\Application\Request\CreationContext;
+use App\Application\Request\Port\RequestCreationGateway;
+use App\Domain\Request\RequestStatus;
+use App\Domain\Request\Role;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Notification\NotificationOutbox;
+use yii\db\Connection;
+
+final readonly class RequestCreationPersistenceAdapter implements RequestCreationGateway
+{
+    public function __construct(private Connection $db)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        $transaction = $this->db->beginTransaction();
+        try {
+            $result = $operation();
+            $transaction->commit();
+            return $result;
+        } catch (\Throwable $error) {
+            $transaction->rollBack();
+            throw $error;
+        }
+    }
+
+    public function creationContext(int $initiatorId): CreationContext
+    {
+        $codes = $this->db->createCommand(
+            'SELECT r.code FROM {{%roles}} r '
+            . 'JOIN {{%user_roles}} ur ON ur.role_id = r.id WHERE ur.user_id = :user_id',
+            [':user_id' => $initiatorId],
+        )->queryColumn();
+        $roles = array_values(array_filter(array_map(
+            static fn (string $code): ?Role => Role::tryFrom($code),
+            $codes,
+        )));
+        $active = $this->db->createCommand(
+            'SELECT 1 FROM {{%users}} WHERE id = :id AND is_active = 1',
+            [':id' => $initiatorId],
+        )->queryScalar() !== false;
+        return new CreationContext($roles, $active);
+    }
+
+    public function departmentSnapshotForUpdate(int $initiatorId): ?string
+    {
+        $department = $this->db->createCommand(
+            'SELECT NULLIF(TRIM(department), \'\') FROM {{%users}} WHERE id = :id FOR UPDATE',
+            [':id' => $initiatorId],
+        )->queryScalar();
+        return $department === false ? null : $department;
+    }
+
+    public function allocateNumber(): int
+    {
+        // MariaDB locks the single counter row and LAST_INSERT_ID keeps the allocated value connection-local.
+        $this->db->createCommand(
+            'UPDATE {{%request_number_sequence}} SET value = LAST_INSERT_ID(value + 1) WHERE id = 1',
+        )->execute();
+        return (int) $this->db->createCommand('SELECT LAST_INSERT_ID()')->queryScalar();
+    }
+
+    public function creationTimestamp(): string
+    {
+        return Clock::now();
+    }
+
+    public function insertRequest(
+        CreateRequestCommand $command,
+        string $department,
+        int $number,
+        string $createdAt,
+    ): int {
+        $this->db->createCommand()->insert('{{%requests}}', [
+            'number' => $number,
+            'initiator_id' => $command->initiatorId,
+            'department_name' => $department,
+            'department_source' => 'current_profile',
+            'status' => RequestStatus::Registered->value,
+            'product_name' => $command->productName,
+            'manufacturer' => $command->manufacturer,
+            'supplier' => $command->supplier,
+            'sample_quantity' => $command->sampleQuantity,
+            'test_method' => $command->testMethod,
+            'created_at' => $createdAt,
+            'updated_at' => $createdAt,
+        ])->execute();
+        return (int) $this->db->getLastInsertID();
+    }
+
+    public function recordCreation(int $requestId, int $actorId, string $createdAt): void
+    {
+        $this->db->createCommand()->insert('{{%request_transitions}}', [
+            'request_id' => $requestId,
+            'actor_id' => $actorId,
+            'from_status' => null,
+            'to_status' => RequestStatus::Registered->value,
+            'action' => 'create',
+            'rule_id' => 'REQ-007',
+            'created_at' => $createdAt,
+        ])->execute();
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.created',
+            'entity_type' => 'request',
+            'entity_id' => $requestId,
+            'actor_id' => $actorId,
+            'rule_id' => 'REQ-007',
+            'payload_json' => ['to_status' => RequestStatus::Registered->value],
+            'created_at' => $createdAt,
+        ])->execute();
+    }
+
+    public function enqueueCreationNotifications(
+        int $requestId,
+        int $number,
+        string $productName,
+        int $initiatorId,
+    ): void {
+        $outbox = new NotificationOutbox($this->db);
+        foreach ($this->activeManagers() as $manager) {
+            $outbox->enqueue(
+                $requestId,
+                'request.created',
+                $manager['email'],
+                $manager['name'],
+                sprintf('Новая заявка №%06d зарегистрирована', $number),
+                sprintf(
+                    "Зарегистрирована новая заявка №%06d на проведение испытаний.\n"
+                    . "Объект испытаний: %s.\n\n"
+                    . 'Откройте реестр заявок в портале, чтобы назначить исполнителя.',
+                    $number,
+                    $productName,
+                ),
+            );
+        }
+        $initiator = $this->userContact($initiatorId);
+        if ($initiator !== null) {
+            $outbox->enqueue(
+                $requestId,
+                'request.created',
+                $initiator['email'],
+                $initiator['name'],
+                sprintf('Заявка №%06d зарегистрирована', $number),
+                sprintf(
+                    "Ваша заявка №%06d на проведение испытаний зарегистрирована.\n"
+                    . "Объект испытаний: %s.\n\n"
+                    . 'Мы сообщим, когда испытательный центр назначит исполнителя.',
+                    $number,
+                    $productName,
+                ),
+            );
+        }
+    }
+
+    public function createdRequest(int $requestId): array
+    {
+        return $this->db->createCommand(
+            'SELECT id, number, legacy_id, initiator_id, status, product_name, manufacturer, supplier, '
+            . 'sample_quantity, legacy_sample_quantity_raw, test_method, revision, lock_version, color, '
+            . 'department_name AS department, created_at, updated_at FROM {{%requests}} WHERE id = :id',
+            [':id' => $requestId],
+        )->queryOne();
+    }
+
+    public function recordRejectedCreation(int $actorId, string $ruleId): void
+    {
+        $active = $this->db->createCommand(
+            'SELECT 1 FROM {{%users}} WHERE id = :id AND is_active = 1',
+            [':id' => $actorId],
+        )->queryScalar() !== false;
+        if (
+            !$active
+            && $this->db->createCommand(
+                'SELECT 1 FROM {{%users}} WHERE id = :id',
+                [':id' => $actorId],
+            )->queryScalar() === false
+        ) {
+            return;
+        }
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.create_denied',
+            'entity_type' => 'request_creation',
+            'entity_id' => $actorId,
+            'actor_id' => $actorId,
+            'rule_id' => $ruleId,
+            'payload_json' => [],
+            'created_at' => Clock::now(),
+        ])->execute();
+    }
+
+    /** @return list<array{email: string, name: string}> */
+    private function activeManagers(): array
+    {
+        return $this->db->createCommand(
+            'SELECT DISTINCT TRIM(u.email) AS email, u.display_name AS name FROM {{%users}} u '
+            . 'JOIN {{%user_roles}} ur ON ur.user_id = u.id JOIN {{%roles}} r ON r.id = ur.role_id '
+            . "WHERE u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != '' "
+            . 'AND r.code IN (:role0,:role1)',
+            [':role0' => 'ic_manager', ':role1' => 'laboratory_manager'],
+        )->queryAll();
+    }
+
+    /** @return array{email: string, name: string}|null */
+    private function userContact(int $userId): ?array
+    {
+        $row = $this->db->createCommand(
+            'SELECT TRIM(email) AS email, display_name AS name FROM {{%users}} '
+            . "WHERE id = :id AND is_active = 1 AND email IS NOT NULL AND TRIM(email) != ''",
+            [':id' => $userId],
+        )->queryOne();
+        return $row === false ? null : $row;
+    }
+}

--- a/backend/src/Infrastructure/Request/RequestRepository.php
+++ b/backend/src/Infrastructure/Request/RequestRepository.php
@@ -4,13 +4,9 @@ declare(strict_types=1);
 
 namespace App\Infrastructure\Request;
 
-use App\Application\Request\CreateRequestInput;
 use App\Domain\Request\CommentPolicy;
-use App\Domain\Request\RequestCreationPolicy;
-use App\Domain\Request\RequestDepartmentMissing;
 use App\Domain\Request\RequestNotFound;
 use App\Domain\Request\RequestStatus;
-use App\Domain\Request\Role;
 use App\Infrastructure\Clock;
 use App\Infrastructure\Notification\NotificationOutbox;
 use yii\db\Connection;
@@ -19,111 +15,6 @@ final class RequestRepository
 {
     public function __construct(private readonly Connection $db)
     {
-    }
-
-    /** @return array<string, mixed> */
-    public function create(CreateRequestInput $input, int $initiatorId): array
-    {
-        $transaction = $this->db->beginTransaction();
-        try {
-            (new RequestCreationPolicy())->assertCanCreate(
-                $this->rolesFor($initiatorId),
-                $this->isActiveUser($initiatorId),
-            );
-            $department = $this->db->createCommand(
-                'SELECT NULLIF(TRIM(department), \'\') FROM {{%users}} WHERE id = :id FOR UPDATE',
-                [':id' => $initiatorId],
-            )->queryScalar();
-            if ($department === false || $department === null) {
-                throw new RequestDepartmentMissing('В профиле пользователя не указано подразделение. Обратитесь к администратору.');
-            }
-
-            // Отдельная строка-счётчик блокируется MariaDB и исключает выдачу
-            // одинакового номера двумя параллельными запросами (REQ-002).
-            $this->db->createCommand(
-                'UPDATE {{%request_number_sequence}} '
-                . 'SET value = LAST_INSERT_ID(value + 1) WHERE id = 1'
-            )->execute();
-            $number = (int) $this->db->createCommand('SELECT LAST_INSERT_ID()')->queryScalar();
-            $now = Clock::now();
-            $this->db->createCommand()->insert('{{%requests}}', [
-                'number' => $number,
-                'initiator_id' => $initiatorId,
-                'department_name' => (string) $department,
-                'department_source' => 'current_profile',
-                'status' => RequestStatus::Registered->value,
-                'product_name' => $input->productName,
-                'manufacturer' => $input->manufacturer,
-                'supplier' => $input->supplier,
-                'sample_quantity' => $input->sampleQuantity,
-                'test_method' => $input->testMethod,
-                'created_at' => $now,
-                'updated_at' => $now,
-            ])->execute();
-            $id = (int) $this->db->getLastInsertID();
-            $this->db->createCommand()->insert('{{%request_transitions}}', [
-                'request_id' => $id,
-                'actor_id' => $initiatorId,
-                'from_status' => null,
-                'to_status' => RequestStatus::Registered->value,
-                'action' => 'create',
-                'rule_id' => 'REQ-007',
-                'created_at' => $now,
-            ])->execute();
-            $this->db->createCommand()->insert('{{%audit_events}}', [
-                'event_type' => 'request.created',
-                'entity_type' => 'request',
-                'entity_id' => $id,
-                'actor_id' => $initiatorId,
-                'rule_id' => 'REQ-007',
-                'payload_json' => ['to_status' => RequestStatus::Registered->value],
-                'created_at' => $now,
-            ])->execute();
-            // REQ-008: руководители ИЦ и лаборатории уведомляются о новой заявке.
-            $outbox = new NotificationOutbox($this->db);
-            foreach ($this->activeUsersWithRoles(['ic_manager', 'laboratory_manager']) as $manager) {
-                $outbox->enqueue(
-                    $id,
-                    'request.created',
-                    $manager['email'],
-                    $manager['name'],
-                    sprintf('Новая заявка №%06d зарегистрирована', $number),
-                    sprintf(
-                        "Зарегистрирована новая заявка №%06d на проведение испытаний.\n"
-                        . "Объект испытаний: %s.\n\n"
-                        . 'Откройте реестр заявок в портале, чтобы назначить исполнителя.',
-                        $number,
-                        $input->productName,
-                    ),
-                );
-            }
-            // REQ-009: инициатора отдельно уведомляют о приёме его же заявки —
-            // без этого письма у него нет подтверждения, что регистрация
-            // прошла успешно и заявка действительно попала в процесс.
-            $initiatorContact = $this->userContact($initiatorId);
-            if ($initiatorContact !== null) {
-                $outbox->enqueue(
-                    $id,
-                    'request.created',
-                    $initiatorContact['email'],
-                    $initiatorContact['name'],
-                    sprintf('Заявка №%06d зарегистрирована', $number),
-                    sprintf(
-                        "Ваша заявка №%06d на проведение испытаний зарегистрирована.\n"
-                        . "Объект испытаний: %s.\n\n"
-                        . 'Мы сообщим, когда испытательный центр назначит исполнителя.',
-                        $number,
-                        $input->productName,
-                    ),
-                );
-            }
-            $transaction->commit();
-
-            return $this->findOne($id);
-        } catch (\Throwable $error) {
-            $transaction->rollBack();
-            throw $error;
-        }
     }
 
     /** @return array<string, mixed> */
@@ -210,82 +101,6 @@ final class RequestRepository
         ])->execute();
     }
 
-    public function recordRejectedCreate(int $actorId, string $ruleId): void
-    {
-        if (!$this->isActiveUser($actorId) && $this->db->createCommand('SELECT 1 FROM {{%users}} WHERE id = :id', [':id' => $actorId])->queryScalar() === false) {
-            return;
-        }
-
-        $this->db->createCommand()->insert('{{%audit_events}}', [
-            'event_type' => 'request.create_denied',
-            'entity_type' => 'request_creation',
-            'entity_id' => $actorId,
-            'actor_id' => $actorId,
-            'rule_id' => $ruleId,
-            'payload_json' => [],
-            'created_at' => Clock::now(),
-        ])->execute();
-    }
-    /** @return list<Role> */
-    public function rolesFor(int $userId): array
-    {
-        $codes = $this->db->createCommand(
-            'SELECT r.code FROM {{%roles}} r '
-            . 'JOIN {{%user_roles}} ur ON ur.role_id = r.id WHERE ur.user_id = :user_id',
-            [':user_id' => $userId],
-        )->queryColumn();
-
-        return array_values(array_filter(array_map(
-            static fn (string $code): ?Role => Role::tryFrom($code),
-            $codes,
-        )));
-    }
-
-    public function isActiveUser(int $userId): bool
-    {
-        return $this->db->createCommand(
-            'SELECT 1 FROM {{%users}} WHERE id = :id AND is_active = 1',
-            [':id' => $userId],
-        )->queryScalar() !== false;
-    }
-
-    /**
-     * @param list<string> $roleCodes
-     * @return list<array{email: string, name: string}>
-     */
-    private function activeUsersWithRoles(array $roleCodes): array
-    {
-        if ($roleCodes === []) {
-            return [];
-        }
-        $placeholders = [];
-        $params = [];
-        foreach ($roleCodes as $index => $code) {
-            $placeholders[] = ":role{$index}";
-            $params[":role{$index}"] = $code;
-        }
-
-        return $this->db->createCommand(
-            'SELECT DISTINCT TRIM(u.email) AS email, u.display_name AS name FROM {{%users}} u '
-            . 'JOIN {{%user_roles}} ur ON ur.user_id = u.id '
-            . 'JOIN {{%roles}} r ON r.id = ur.role_id '
-            . "WHERE u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != '' "
-            . 'AND r.code IN (' . implode(',', $placeholders) . ')',
-            $params,
-        )->queryAll();
-    }
-
-    /** @return array{email: string, name: string}|null */
-    private function userContact(int $userId): ?array
-    {
-        $row = $this->db->createCommand(
-            'SELECT TRIM(email) AS email, display_name AS name FROM {{%users}} '
-            . "WHERE id = :id AND is_active = 1 AND email IS NOT NULL AND TRIM(email) != ''",
-            [':id' => $userId],
-        )->queryOne();
-
-        return $row === false ? null : $row;
-    }
 
     /** @return list<array{id: int, email: string, name: string}> */
     private function processParticipants(int $requestId): array
@@ -301,17 +116,5 @@ final class RequestRepository
             . "AND u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != ''",
             [':request_id1' => $requestId, ':request_id2' => $requestId],
         )->queryAll();
-    }
-
-    /** @return array<string, mixed> */
-    private function findOne(int $id): array
-    {
-        return $this->db->createCommand(
-            'SELECT id, number, legacy_id, initiator_id, status, product_name, manufacturer, supplier, '
-            . 'sample_quantity, legacy_sample_quantity_raw, test_method, revision, lock_version, color, '
-            . 'department_name AS department, '
-            . 'created_at, updated_at FROM {{%requests}} WHERE id = :id',
-            [':id' => $id],
-        )->queryOne();
     }
 }

--- a/backend/tests/Integration/Document/DocumentRepositoryTest.php
+++ b/backend/tests/Integration/Document/DocumentRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Document;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Domain\Request\ConcurrentRequestModification;
 use App\Domain\Request\ReportDeletionDenied;
 use App\Domain\Request\ReportDenied;
@@ -71,7 +71,7 @@ final class DocumentRepositoryTest extends IntegrationTestCase
         $input->supplier = 'Поставщик';
         $input->sampleQuantity = 1;
         $input->testMethod = 'Интеграционный тест';
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         $requestId = (int) $request['id'];
         $now = Clock::now();
 

--- a/backend/tests/Integration/Document/TestActDocumentServiceTest.php
+++ b/backend/tests/Integration/Document/TestActDocumentServiceTest.php
@@ -7,7 +7,7 @@ namespace Tests\Integration\Document;
 use App\Application\Document\TestActDocumentService;
 use App\Application\Document\TestActInput;
 use App\Application\Document\TestActConfigurationError;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Domain\Request\ReportDenied;
 use App\Domain\Request\RequestNotFound;
 use App\Infrastructure\Clock;
@@ -132,7 +132,7 @@ final class TestActDocumentServiceTest extends IntegrationTestCase
         $input->supplier = 'Поставщик';
         $input->sampleQuantity = 2;
         $input->testMethod = 'Проверка маркировки';
-        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiator))->toArray();
         $requestId = (int) $request['id'];
         $this->db()->createCommand()->update('{{%requests}}', ['status' => 'in_progress'], ['id' => $requestId])->execute();
         $this->db()->createCommand()->insert('{{%request_assignments}}', [

--- a/backend/tests/Integration/Http/ChangeRequestDepartmentHttpTest.php
+++ b/backend/tests/Integration/Http/ChangeRequestDepartmentHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\RequestDepartmentGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Request\RequestRepository;
@@ -108,7 +108,7 @@ final class ChangeRequestDepartmentHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         return [(int) $request['id'], (int) $request['lock_version'], $administratorId];
     }
 

--- a/backend/tests/Integration/Http/ExecutorAssignmentHttpTest.php
+++ b/backend/tests/Integration/Http/ExecutorAssignmentHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\ExecutorAssignmentGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Persistence\Request\ExecutorAssignmentPersistenceAdapter;
@@ -115,7 +115,7 @@ final class ExecutorAssignmentHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         return [(int) $request['id'], (int) $request['lock_version'], $managerId, $executorId];
     }
 

--- a/backend/tests/Integration/Http/ExpertAssignmentHttpTest.php
+++ b/backend/tests/Integration/Http/ExpertAssignmentHttpTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Http;
 
 use App\Application\Request\Command\AssignExpertCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\ExpertAssignmentGateway;
 use App\Application\Request\UseCase\AssignExpert;
 use App\Http\Controller\RequestController;
@@ -159,7 +159,7 @@ final class ExpertAssignmentHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiator))->toArray();
         $this->db()->createCommand()->update(
             '{{%requests}}',
             ['status' => 'opinion_preparation'],

--- a/backend/tests/Integration/Http/RequestCancellationHttpTest.php
+++ b/backend/tests/Integration/Http/RequestCancellationHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\RequestCancellationGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Persistence\Request\RequestCancellationPersistenceAdapter;
@@ -75,7 +75,7 @@ final class RequestCancellationHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
 
         return [(int) $request['id'], (int) $request['lock_version'], $initiatorId, $managerId];
     }

--- a/backend/tests/Integration/Http/RequestLifecycleHttpTest.php
+++ b/backend/tests/Integration/Http/RequestLifecycleHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\RequestLifecycleGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Persistence\Request\RequestLifecyclePersistenceAdapter;
@@ -102,7 +102,7 @@ final class RequestLifecycleHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         return [(int) $request['id'], (int) $request['lock_version'], $managerId];
     }
 

--- a/backend/tests/Integration/Http/SecurityDecisionHttpTest.php
+++ b/backend/tests/Integration/Http/SecurityDecisionHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\SecurityDecisionGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Clock;
@@ -108,7 +108,7 @@ final class SecurityDecisionHttpTest extends IntegrationTestCase
             'productName' => "HTTP security {$marker}", 'manufacturer' => 'Завод', 'supplier' => 'Поставщик',
             'sampleQuantity' => 1, 'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiator))->toArray();
         $requestId = (int) $request['id'];
         $this->db()->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
         $this->db()->createCommand()->insert('{{%request_documents}}', [

--- a/backend/tests/Integration/Http/SetRequestColorHttpTest.php
+++ b/backend/tests/Integration/Http/SetRequestColorHttpTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Http;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Port\RequestColorGateway;
 use App\Http\Controller\RequestController;
 use App\Infrastructure\Request\RequestRepository;
@@ -101,7 +101,7 @@ final class SetRequestColorHttpTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         return [(int) $request['id'], (int) $request['lock_version'], $managerId];
     }
 

--- a/backend/tests/Integration/Import/BitrixArchiveFileImporterTest.php
+++ b/backend/tests/Integration/Import/BitrixArchiveFileImporterTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Import;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Infrastructure\Document\DocumentStorage;
 use App\Infrastructure\Import\BitrixArchiveFileImporter;
 use App\Infrastructure\Request\RequestRepository;
@@ -42,7 +42,7 @@ final class BitrixArchiveFileImporterTest extends IntegrationTestCase
         $input->supplier = 'Поставщик';
         $input->sampleQuantity = 1;
         $input->testMethod = 'Методика';
-        $request = (new RequestRepository($this->db()))->create($input, $userId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($userId))->toArray();
         $this->db()->createCommand()->update('{{%requests}}', [
             'legacy_id' => 'bitrix24:114:42',
             'source' => 'bitrix24',
@@ -206,7 +206,7 @@ final class BitrixArchiveFileImporterTest extends IntegrationTestCase
         $input->supplier = 'Поставщик';
         $input->sampleQuantity = 1;
         $input->testMethod = 'Методика';
-        $request = (new RequestRepository($this->db()))->create($input, $userId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($userId))->toArray();
         $this->db()->createCommand()->update('{{%requests}}', [
             'legacy_id' => 'bitrix24:114:77', 'source' => 'bitrix24', 'is_archived' => 1,
         ], ['id' => $request['id']])->execute();

--- a/backend/tests/Integration/Import/BitrixArchiveMetadataMigrationTest.php
+++ b/backend/tests/Integration/Import/BitrixArchiveMetadataMigrationTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Import;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Infrastructure\Request\RequestRepository;
 use RuntimeException;
 use Tests\Integration\IntegrationTestCase;
@@ -21,7 +21,7 @@ final class BitrixArchiveMetadataMigrationTest extends IntegrationTestCase
         $input->supplier = 'Поставщик';
         $input->sampleQuantity = 1;
         $input->testMethod = 'Методика';
-        $request = (new RequestRepository($this->db()))->create($input, $userId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($userId))->toArray();
         foreach (['bitrix24:file:one', 'bitrix24:file:two'] as $legacyId) {
             $this->db()->createCommand()->insert('{{%request_documents}}', [
                 'legacy_id' => $legacyId,

--- a/backend/tests/Integration/Request/AttentionDashboardTest.php
+++ b/backend/tests/Integration/Request/AttentionDashboardTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Request;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Command\AssignExecutorCommand;
 use App\Application\Request\UseCase\AssignExecutor;
 use App\Infrastructure\Clock;
@@ -221,7 +221,7 @@ final class AttentionDashboardTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Интеграционная проверка очередей',
         ]);
-        return (new RequestRepository($this->db()))->create($input, $initiator);
+        return (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiator))->toArray();
     }
 
     private function updateStatus(int $requestId, string $status): void

--- a/backend/tests/Integration/Request/ChangeRequestDepartmentAuditAtomicityTest.php
+++ b/backend/tests/Integration/Request/ChangeRequestDepartmentAuditAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\ChangeRequestDepartmentCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\ChangeRequestDepartment;
 use App\Infrastructure\Persistence\Request\RequestDepartmentPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
@@ -33,8 +33,9 @@ final class ChangeRequestDepartmentAuditAtomicityTest extends TestCase
                 'sampleQuantity' => 1,
                 'testMethod' => 'Методика',
             ]);
-            $repository = new RequestRepository($db);
-            $request = $repository->create($input, $initiatorId);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(
+                new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db),
+            ))->execute($input->toCommand($initiatorId))->toArray();
             $db->createCommand()->update('{{%requests}}', [
                 'department_external_id' => 'bitrix:atomicity',
                 'department_source' => 'bitrix24',

--- a/backend/tests/Integration/Request/ExecutorAssignmentAtomicityTest.php
+++ b/backend/tests/Integration/Request/ExecutorAssignmentAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\AssignExecutorCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\AssignExecutor;
 use App\Infrastructure\Persistence\Request\ExecutorAssignmentPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
@@ -35,7 +35,7 @@ final class ExecutorAssignmentAtomicityTest extends TestCase
                 'sampleQuantity' => 1,
                 'testMethod' => 'Методика',
             ]);
-            $request = (new RequestRepository($db))->create($input, $initiatorId);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db)))->execute($input->toCommand($initiatorId))->toArray();
 
             try {
                 (new AssignExecutor(new ExecutorAssignmentPersistenceAdapter($db)))->execute(

--- a/backend/tests/Integration/Request/RequestAssignmentConcurrencyTest.php
+++ b/backend/tests/Integration/Request/RequestAssignmentConcurrencyTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Request;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Infrastructure\Request\RequestRepository;
 use PHPUnit\Framework\TestCase;
 use yii\db\Connection;
@@ -36,7 +36,7 @@ final class RequestAssignmentConcurrencyTest extends TestCase
             $input->supplier = 'Test supplier';
             $input->sampleQuantity = 1;
             $input->testMethod = 'Controlled two-session assignment';
-            $request = (new RequestRepository($db))->create($input, $users['initiator']);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db)))->execute($input->toCommand($users['initiator']))->toArray();
             $requestId = (int) $request['id'];
             $version = (int) $request['lock_version'];
 

--- a/backend/tests/Integration/Request/RequestCancellationAtomicityTest.php
+++ b/backend/tests/Integration/Request/RequestCancellationAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\CancelRequestCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\CancelRequest;
 use App\Domain\Request\RequestAction;
 use App\Infrastructure\Persistence\Request\RequestCancellationPersistenceAdapter;
@@ -34,7 +34,7 @@ final class RequestCancellationAtomicityTest extends TestCase
                 'sampleQuantity' => 1,
                 'testMethod' => 'Методика',
             ]);
-            $request = (new RequestRepository($db))->create($input, $initiatorId);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db)))->execute($input->toCommand($initiatorId))->toArray();
 
             try {
                 (new CancelRequest(new RequestCancellationPersistenceAdapter($db)))->execute(

--- a/backend/tests/Integration/Request/RequestCreationAuditAtomicityTest.php
+++ b/backend/tests/Integration/Request/RequestCreationAuditAtomicityTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Request;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Infrastructure\Request\RequestRepository;
 use PHPUnit\Framework\TestCase;
 use yii\db\Connection;
@@ -39,7 +39,9 @@ final class RequestCreationAuditAtomicityTest extends TestCase
             $input->testMethod = 'Интеграционный тест';
 
             try {
-                (new RequestRepository($db))->create($input, $initiatorId);
+                (new \App\Application\Request\UseCase\CreateRequest(
+                    new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db),
+                ))->execute($input->toCommand($initiatorId));
                 self::fail('Expected the controlled audit write to fail.');
             } catch (\RuntimeException $error) {
                 self::assertStringContainsString('controlled request creation audit failure', $error->getMessage());

--- a/backend/tests/Integration/Request/RequestLifecycleAtomicityTest.php
+++ b/backend/tests/Integration/Request/RequestLifecycleAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\RequestLifecycleCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\RequestLifecycle;
 use App\Domain\Request\RequestAction;
 use App\Infrastructure\Persistence\Request\RequestLifecyclePersistenceAdapter;
@@ -34,7 +34,7 @@ final class RequestLifecycleAtomicityTest extends TestCase
                 'sampleQuantity' => 1,
                 'testMethod' => 'Методика',
             ]);
-            $request = (new RequestRepository($db))->create($input, $initiatorId);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db)))->execute($input->toCommand($initiatorId))->toArray();
 
             try {
                 (new RequestLifecycle(new RequestLifecyclePersistenceAdapter($db)))->execute(

--- a/backend/tests/Integration/Request/RequestRepositoryTest.php
+++ b/backend/tests/Integration/Request/RequestRepositoryTest.php
@@ -4,7 +4,7 @@ declare(strict_types=1);
 
 namespace Tests\Integration\Request;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\Command\AssignExecutorCommand;
 use App\Application\Request\Command\AssignExpertCommand;
 use App\Application\Request\Command\ExpertAssignmentAction;
@@ -95,7 +95,7 @@ final class RequestRepositoryTest extends IntegrationTestCase
         $input->sampleQuantity = 1;
         $input->testMethod = 'Интеграционный тест';
 
-        return (new RequestRepository($this->db()))->create($input, $initiatorId);
+        return (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
     }
 
     public function testCreationWritesOneSafeAuditEventPresentedAsRequestCreation(): void

--- a/backend/tests/Integration/Request/SecurityDecisionAtomicityTest.php
+++ b/backend/tests/Integration/Request/SecurityDecisionAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\DecideSecurityCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\DecideSecurity;
 use App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter;
 use App\Infrastructure\Request\RequestRepository;
@@ -30,7 +30,7 @@ final class SecurityDecisionAtomicityTest extends TestCase
                 'productName' => "Security atomicity {$marker}", 'manufacturer' => 'Завод',
                 'supplier' => 'Поставщик', 'sampleQuantity' => 1, 'testMethod' => 'Методика',
             ]);
-            $request = (new RequestRepository($db))->create($input, $initiator);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db)))->execute($input->toCommand($initiator))->toArray();
             $requestId = (int) $request['id'];
             $db->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
             $db->createCommand()->insert('{{%request_documents}}', [

--- a/backend/tests/Integration/Request/SecurityDecisionTest.php
+++ b/backend/tests/Integration/Request/SecurityDecisionTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\DecideSecurityCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\DecideSecurity;
 use App\Domain\Request\ConcurrentRequestModification;
 use App\Domain\Request\RequestNotFound;
@@ -209,7 +209,7 @@ final class SecurityDecisionTest extends IntegrationTestCase
             'productName' => "Security {$marker}", 'manufacturer' => 'Завод', 'supplier' => 'Поставщик',
             'sampleQuantity' => 1, 'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiator);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiator))->toArray();
         $requestId = (int) $request['id'];
         $this->db()->createCommand()->update('{{%requests}}', ['status' => 'security_review'], ['id' => $requestId])->execute();
         $this->db()->createCommand()->insert('{{%request_assignments}}', [

--- a/backend/tests/Integration/Request/SetRequestColorAuditAtomicityTest.php
+++ b/backend/tests/Integration/Request/SetRequestColorAuditAtomicityTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\SetRequestColorCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Domain\Request\RequestColor;
 use App\Infrastructure\Persistence\Request\RequestColorPersistenceAdapter;
@@ -34,8 +34,9 @@ final class SetRequestColorAuditAtomicityTest extends TestCase
                 'sampleQuantity' => 1,
                 'testMethod' => 'Методика',
             ]);
-            $repository = new RequestRepository($db);
-            $request = $repository->create($input, $initiatorId);
+            $request = (new \App\Application\Request\UseCase\CreateRequest(
+                new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($db),
+            ))->execute($input->toCommand($initiatorId))->toArray();
 
             try {
                 (new SetRequestColor(new RequestColorPersistenceAdapter($db)))->execute(new SetRequestColorCommand(

--- a/backend/tests/Integration/Request/SetRequestColorTest.php
+++ b/backend/tests/Integration/Request/SetRequestColorTest.php
@@ -5,7 +5,7 @@ declare(strict_types=1);
 namespace Tests\Integration\Request;
 
 use App\Application\Request\Command\SetRequestColorCommand;
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Domain\Request\ColorMarkDenied;
 use App\Domain\Request\ConcurrentRequestModification;
@@ -98,7 +98,7 @@ final class SetRequestColorTest extends IntegrationTestCase
             'sampleQuantity' => 1,
             'testMethod' => 'Методика',
         ]);
-        $request = (new RequestRepository($this->db()))->create($input, $initiatorId);
+        $request = (new \App\Application\Request\UseCase\CreateRequest(new \App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter($this->db())))->execute($input->toCommand($initiatorId))->toArray();
         return [(int) $request['id'], (int) $request['lock_version'], $managerId];
     }
 

--- a/backend/tests/Unit/Application/Request/CreateRequestTest.php
+++ b/backend/tests/Unit/Application/Request/CreateRequestTest.php
@@ -1,0 +1,43 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Request;
+
+use App\Application\Request\Command\CreateRequestCommand;
+use App\Application\Request\CreationContext;
+use App\Application\Request\Port\RequestCreationGateway;
+use App\Application\Request\UseCase\CreateRequest;
+use App\Domain\Request\RequestCreationDenied;
+use App\Domain\Request\Role;
+use PHPUnit\Framework\TestCase;
+
+final class CreateRequestTest extends TestCase
+{
+    public function testDeniedRoleIsRejectedBeforeDepartmentLockAndNumberAllocation(): void
+    {
+        $gateway = $this->createMock(RequestCreationGateway::class);
+        $gateway->method('transactional')->willReturnCallback(static fn (callable $operation): mixed => $operation());
+        $gateway->expects(self::once())->method('creationContext')
+            ->willReturn(new CreationContext([Role::IcManager], true));
+        $gateway->expects(self::never())->method('departmentSnapshotForUpdate');
+        $gateway->expects(self::never())->method('allocateNumber');
+
+        $this->expectException(RequestCreationDenied::class);
+        (new CreateRequest($gateway))->execute($this->command());
+    }
+
+    public function testRejectedAuditIsDelegatedWithoutStartingCreationTransaction(): void
+    {
+        $gateway = $this->createMock(RequestCreationGateway::class);
+        $gateway->expects(self::never())->method('transactional');
+        $gateway->expects(self::once())->method('recordRejectedCreation')->with(42, 'REQ-001');
+
+        (new CreateRequest($gateway))->recordRejected($this->command(), 'REQ-001');
+    }
+
+    private function command(): CreateRequestCommand
+    {
+        return new CreateRequestCommand(42, 'Образец', 'Завод', 'Поставщик', 1, 'Методика');
+    }
+}

--- a/backend/tests/Unit/Http/Request/CreateRequestTest.php
+++ b/backend/tests/Unit/Http/Request/CreateRequestTest.php
@@ -2,12 +2,12 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Application\Request;
+namespace Tests\Unit\Http\Request;
 
-use App\Application\Request\CreateRequestInput;
+use App\Http\Request\CreateRequest as CreateRequestInput;
 use PHPUnit\Framework\TestCase;
 
-final class CreateRequestInputTest extends TestCase
+final class CreateRequestTest extends TestCase
 {
     public function testValidRequestDataPassesValidation(): void
     {

--- a/backend/tools/architecture-baseline.php
+++ b/backend/tools/architecture-baseline.php
@@ -17,7 +17,6 @@ return [
         'backend/src/Application/Identity/LoginInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Identity/RevokeRoleInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/AddCommentInput.php' => ['yii\\base\\Model'],
-        'backend/src/Application/Request/CreateRequestInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/ListRequestsInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/PublishOpinionInput.php' => ['yii\\base\\Model'],
         'backend/src/Http/Controller/AdminController.php' => [
@@ -103,9 +102,6 @@ return [
         'backend/src/Infrastructure/Request/RequestQuery.php' => [
             'RequestQuery::findDetails' => 261,
             'RequestQuery::findPage' => 233,
-        ],
-        'backend/src/Infrastructure/Request/RequestRepository.php' => [
-            'RequestRepository::create' => 103,
         ],
     ],
 ];


### PR DESCRIPTION
## Цель

Wave 10 выносит создание заявки и denied audit этого сценария из `RequestRepository` в отдельный application vertical slice, сохраняя действующий контракт без изменения бизнес-правил.

Новый execution path:

`HTTP validation → CreateRequestCommand → CreateRequest use case → RequestCreationPolicy → RequestCreationGateway → RequestCreationPersistenceAdapter`

## Что изменено

- добавлены `CreateRequestCommand`, application use case `CreateRequest` и `RequestCreationGateway`;
- добавлен специализированный `RequestCreationPersistenceAdapter`;
- добавлены минимальные typed `CreationContext` и `CreateRequestResult`;
- Yii validation перенесена из Application в `Http\Request\CreateRequest`;
- `CreateRequestInput` удалён из Application;
- `RequestController` теперь только валидирует HTTP-ввод, строит command, переводит доменные ошибки в прежние HTTP-ответы и формирует неизменный `201` response;
- `RequestRepository::create`, `recordRejectedCreate` и все исключительно create helpers удалены;
- integration fixtures переведены на новый публичный use-case boundary;
- architecture baseline уменьшен: удалены Yii dependency exception и oversized-method exception legacy `RequestRepository::create`.

После изменения `RequestRepository` отвечает только за comments, `recordRejectedColor` и общий для comment workflow `processParticipants`.

## Сохранённый legacy contract

- authorization выполняется существующим `RequestCreationPolicy`;
- сохранены active-state и ограничения ролей `REQ-001` / `AUTH-003`;
- policy выполняется до department lock, поэтому denied create не получает новый `FOR UPDATE` lock;
- department snapshot читается прежним `NULLIF(TRIM(department), '') ... FOR UPDATE` и сохраняется с `department_source=current_profile`;
- номер выделяется прежним MariaDB primitive `UPDATE request_number_sequence SET value = LAST_INSERT_ID(value + 1)` с connection-local `LAST_INSERT_ID()`;
- сохранён порядок locking и persistence: authorization → department snapshot → number allocation → request INSERT → initial transition → mandatory audit → outbox → commit;
- используется одна Yii transaction с прежней savepoint-aware вложенной семантикой;
- начальный статус — `registered`;
- initial transition — `null → registered`, action `create`, rule `REQ-007`;
- audit `request.created`, entity, rule ID и payload `{"to_status":"registered"}` не изменены;
- denied audit `request.create_denied` сохраняет прежние entity/payload и best-effort semantics контроллера;
- сохранены обе группы руководителей (`ic_manager`, `laboratory_manager`), инициатор, дедупликация dual-role получателя и trim/filter email;
- subjects и bodies уведомлений оставлены без изменений;
- HTTP response shape, `Location` и существующие 403/409/422 contracts не изменены.

Mandatory audit failure откатывает request, initial transition и outbox. Фактическая транзакционная семантика sequence allocation не менялась.

## Тесты и гарантии

Существующий regression contour продолжает проверять:

- успешное создание, статус и initial transition;
- department snapshot и отсутствие создания без подразделения;
- number allocation и параллельные/replayed POST;
- `request.created` audit и его payload;
- manager/initiator recipients, dual-role deduplication, email normalization, subject/body;
- rollback при обязательном audit failure;
- HTTP validation, response и idempotency contracts.

Добавлен application unit test, фиксирующий, что запрещённая роль отклоняется до department lock и number allocation, а denied audit делегируется отдельно от creation transaction.

## Метрики

- `RequestRepository`: 317 → 120 LOC;
- `RequestController`: 868 → 868 LOC;
- architecture dependency exceptions: 18 → 17;
- architecture dependency edges: 52 → 51;
- oversized methods baseline: 11 → 10;
- production LOC: +419 / −232, net +187;
- test LOC: +170 / −123, net +47.

## Проверка

- `make check` — passed: 459 backend unit tests / 912 assertions, 264 frontend tests, PHPStan, lint, build, dependency audit, architecture и repository guards;
- `make e2e` — passed: 290 MariaDB integration tests / 1862 assertions, 16 Playwright tests, SMTP/recovery/SIGTERM checks;
- `make coverage` — passed: 749 PHP tests / 2774 assertions, domain/application statement coverage 95.50%, frontend statements 95.51%, lines 96.57%;
- независимый read-only `$pr-review` относительно `origin/main` — actionable findings отсутствуют.

`phpunit.coverage.xml` вручную не изменялся.

## Риски

Риск высокий, поскольку меняется архитектурный путь критического workflow создания заявки. Бизнес-правила, SQL primitives, транзакционная граница и HTTP/OpenAPI contract не менялись. Основные риски — изменение порядка lock, частичный commit при audit/outbox failure и расхождение notifications — закрыты regression, atomicity и E2E-проверками.

Исторические особенности намеренно не исправлялись: policy запрещает конкретные ИЦ-роли вместо явного требования employee; roles/active читаются до блокировки профиля; denied audit остаётся отдельным best-effort действием; sequence использует connection-local `LAST_INSERT_ID`.

## Rollback

Откатить один commit этого PR. Миграций и изменений схемы/данных нет, поэтому отдельная DB rollback-процедура не требуется. После отката controller снова вызовет legacy `RequestRepository::create`, а прежний Application `CreateRequestInput` восстановится.

## Не входит в scope

- comments и `recordRejectedColor`;
- lifecycle, cancellation, assignment и security slices;
- documents и `RequestQuery`/read side;
- frontend;
- изменение исторических business rules или notification texts.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a streamlined request-creation workflow with validation for initiator eligibility, active status, and department assignment.
  * Requests now receive consistent numbering and creation details, with notifications sent to relevant parties.
  * Rejected creation attempts are recorded for audit purposes.

* **Bug Fixes**
  * Improved transaction handling so failed request creation does not leave partial records or audit entries.

* **Tests**
  * Expanded coverage for validation, auditing, rollback behavior, and request lifecycle scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->