### PR TITLE
refactor(documents): extract opinion publishing

### DIFF
--- a/backend/config/common.php
+++ b/backend/config/common.php
@@ -29,6 +29,14 @@ return [
                 new App\Infrastructure\Persistence\Request\ExpertAssignmentPersistenceAdapter(Yii::$app->db),
             App\Application\Request\Port\SecurityDecisionGateway::class => static fn () =>
                 new App\Infrastructure\Persistence\Request\SecurityDecisionPersistenceAdapter(Yii::$app->db),
+            App\Application\Request\Port\PublishOpinionGateway::class => static fn () =>
+                new App\Infrastructure\Persistence\Request\PublishOpinionPersistenceAdapter(
+                    Yii::$app->db,
+                    new App\Infrastructure\Document\DocumentStorage(
+                        getenv('DOCUMENT_STORAGE_PATH') ?: '/app/storage/documents',
+                    ),
+                ),
+            App\Application\Request\Port\OpinionRenderer::class => App\Infrastructure\Document\OpinionRendererAdapter::class,
             App\Application\Request\Port\RequestCreationGateway::class => static fn () =>
                 new App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter(Yii::$app->db),
         ],

--- a/backend/src/Application/Request/Command/PublishOpinionCommand.php
+++ b/backend/src/Application/Request/Command/PublishOpinionCommand.php
@@ -1,0 +1,16 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Command;
+
+final readonly class PublishOpinionCommand
+{
+    public function __construct(
+        public int $requestId,
+        public int $actorId,
+        public string $body,
+        public int $expectedLockVersion,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/Port/OpinionRenderer.php
+++ b/backend/src/Application/Request/Port/OpinionRenderer.php
@@ -1,0 +1,12 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Port;
+
+use App\Application\Request\PublishOpinionSnapshot;
+
+interface OpinionRenderer
+{
+    public function render(PublishOpinionSnapshot $snapshot, string $body): string;
+}

--- a/backend/src/Application/Request/Port/PublishOpinionGateway.php
+++ b/backend/src/Application/Request/Port/PublishOpinionGateway.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\Port;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\PublishOpinionSnapshot;
+
+interface PublishOpinionGateway
+{
+    /**
+     * @template T
+     * @param callable(): T $operation
+     * @return T
+     */
+    public function transactional(callable $operation): mixed;
+
+    public function snapshotForUpdate(int $requestId, int $actorId): ?PublishOpinionSnapshot;
+
+    public function nextRevision(int $requestId): int;
+
+    public function persistPublication(
+        PublishOpinionCommand $command,
+        PublishOpinionSnapshot $snapshot,
+        int $revision,
+        string $pdf,
+    ): int;
+
+    public function recordRejected(int $requestId, int $actorId, string $ruleId): void;
+}

--- a/backend/src/Application/Request/PublishOpinionResult.php
+++ b/backend/src/Application/Request/PublishOpinionResult.php
@@ -1,0 +1,31 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+use App\Domain\Request\RequestStatus;
+
+final readonly class PublishOpinionResult
+{
+    public function __construct(
+        public int $requestId,
+        public int $revision,
+        public int $documentVersionId,
+        public RequestStatus $status,
+        public int $lockVersion,
+    ) {
+    }
+
+    /** @return array{requestId: int, revision: int, documentVersionId: int, status: string, lockVersion: int} */
+    public function toArray(): array
+    {
+        return [
+            'requestId' => $this->requestId,
+            'revision' => $this->revision,
+            'documentVersionId' => $this->documentVersionId,
+            'status' => $this->status->value,
+            'lockVersion' => $this->lockVersion,
+        ];
+    }
+}

--- a/backend/src/Application/Request/PublishOpinionSnapshot.php
+++ b/backend/src/Application/Request/PublishOpinionSnapshot.php
@@ -1,0 +1,24 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request;
+
+use App\Domain\Request\RequestStatus;
+
+final readonly class PublishOpinionSnapshot
+{
+    public function __construct(
+        public int $number,
+        public RequestStatus $status,
+        public int $lockVersion,
+        public string $productName,
+        public string $manufacturer,
+        public string $supplier,
+        public string $expertName,
+        public string $expertPosition,
+        public bool $actorIsActive,
+        public bool $isCurrentExpert,
+    ) {
+    }
+}

--- a/backend/src/Application/Request/UseCase/PublishOpinion.php
+++ b/backend/src/Application/Request/UseCase/PublishOpinion.php
@@ -1,0 +1,60 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Application\Request\UseCase;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\Port\OpinionRenderer;
+use App\Application\Request\Port\PublishOpinionGateway;
+use App\Application\Request\PublishOpinionResult;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\OpinionPolicy;
+use App\Domain\Request\RequestNotFound;
+use App\Domain\Request\RequestStatus;
+
+final readonly class PublishOpinion
+{
+    public function __construct(
+        private PublishOpinionGateway $gateway,
+        private OpinionRenderer $renderer,
+        private OpinionPolicy $policy = new OpinionPolicy(),
+    ) {
+    }
+
+    public function execute(PublishOpinionCommand $command): PublishOpinionResult
+    {
+        return $this->gateway->transactional(function () use ($command): PublishOpinionResult {
+            $snapshot = $this->gateway->snapshotForUpdate($command->requestId, $command->actorId);
+            if ($snapshot === null) {
+                throw new RequestNotFound('Request not found');
+            }
+            $this->policy->assertCanPublish(
+                $snapshot->status,
+                $snapshot->actorIsActive,
+                $snapshot->isCurrentExpert,
+            );
+            if ($snapshot->lockVersion !== $command->expectedLockVersion) {
+                throw new ConcurrentRequestModification();
+            }
+
+            $revision = $this->gateway->nextRevision($command->requestId);
+            $pdf = $this->renderer->render($snapshot, $command->body);
+            $versionId = $this->gateway->persistPublication($command, $snapshot, $revision, $pdf);
+            $nextLockVersion = $command->expectedLockVersion + 1;
+
+            return new PublishOpinionResult(
+                $command->requestId,
+                $revision,
+                $versionId,
+                RequestStatus::SecurityReview,
+                $nextLockVersion,
+            );
+        });
+    }
+
+    public function recordRejected(PublishOpinionCommand $command, string $ruleId): void
+    {
+        $this->gateway->recordRejected($command->requestId, $command->actorId, $ruleId);
+    }
+}

--- a/backend/src/Http/Controller/RequestController.php
+++ b/backend/src/Http/Controller/RequestController.php
@@ -14,8 +14,9 @@ use App\Application\Request\Command\AssignExpertCommand;
 use App\Application\Request\Command\AssignExecutorCommand;
 use App\Application\Request\Command\CancelRequestCommand;
 use App\Application\Request\Command\DecideSecurityCommand;
-use App\Application\Request\PublishOpinionInput;
+use App\Application\Request\Command\PublishOpinionCommand;
 use App\Application\Request\UseCase\DecideSecurity;
+use App\Application\Request\UseCase\PublishOpinion;
 use App\Application\Request\UseCase\CreateRequest as CreateRequestUseCase;
 use App\Application\Request\UseCase\SetRequestColor;
 use App\Application\Request\UseCase\RequestLifecycle;
@@ -48,7 +49,6 @@ use App\Infrastructure\Identity\CurrentUser;
 use App\Infrastructure\Document\DocumentRepository;
 use App\Infrastructure\Document\DocumentStorage;
 use App\Infrastructure\Document\OfficeDocumentInspector;
-use App\Infrastructure\Document\OpinionPdfRenderer;
 use App\Infrastructure\Document\TestActDocumentGenerator;
 use App\Infrastructure\Request\RequestQuery;
 use App\Http\Request\AddCommentRequest;
@@ -60,6 +60,7 @@ use App\Http\Request\CancelRequest;
 use App\Http\Request\AssignExecutorRequest;
 use App\Http\Request\AssignExpertRequest;
 use App\Http\Request\SecurityDecisionRequest;
+use App\Http\Request\PublishOpinionRequest;
 use App\Http\Request\CreateRequest;
 use Yii;
 use yii\web\Response;
@@ -523,27 +524,21 @@ final class RequestController extends ApiController
     /** @return array<string, mixed> */
     public function actionPublishOpinion(int $id): array
     {
-        $input = new PublishOpinionInput();
+        $input = new PublishOpinionRequest();
         if (($errors = $this->bodyValidationErrors($input)) !== null) {
             return $errors;
         }
 
-        $actorId = $this->currentUserId();
+        $command = $input->toCommand($id, $this->currentUserId());
         try {
-            return $this->documents()->publishOpinion(
-                $id,
-                $actorId,
-                trim((string) $input->body),
-                (int) $input->lockVersion,
-                new OpinionPdfRenderer(),
-            );
+            return Yii::$container->get(PublishOpinion::class)->execute($command)->toArray();
         } catch (RequestNotFound $error) {
             throw new NotFoundHttpException($error->getMessage());
         } catch (OpinionDenied $error) {
-            $this->recordRejectedOpinionSafely($id, $actorId, $error->ruleId);
+            $this->recordRejectedOpinionSafely($command, $error->ruleId);
             throw new ForbiddenHttpException($error->getMessage());
         } catch (ConcurrentRequestModification $error) {
-            $this->recordRejectedOpinionSafely($id, $actorId, $error->ruleId);
+            $this->recordRejectedOpinionSafely($command, $error->ruleId);
             throw new ConflictHttpException($error->getMessage());
         }
     }
@@ -794,12 +789,12 @@ final class RequestController extends ApiController
         );
     }
 
-    private function recordRejectedOpinionSafely(int $requestId, int $actorId, string $ruleId): void
+    private function recordRejectedOpinionSafely(PublishOpinionCommand $command, string $ruleId): void
     {
         $this->recordRejectedSafely(
-            fn () => $this->documents()->recordRejectedOpinion($requestId, $actorId, $ruleId),
+            fn () => Yii::$container->get(PublishOpinion::class)->recordRejected($command, $ruleId),
             'Не удалось записать аудит отклонённой публикации заключения.',
-            ['requestId' => $requestId, 'actorId' => $actorId, 'ruleId' => $ruleId],
+            ['requestId' => $command->requestId, 'actorId' => $command->actorId, 'ruleId' => $ruleId],
             __METHOD__,
         );
     }

--- a/backend/src/Http/Request/PublishOpinionRequest.php
+++ b/backend/src/Http/Request/PublishOpinionRequest.php
@@ -2,11 +2,12 @@
 
 declare(strict_types=1);
 
-namespace App\Application\Request;
+namespace App\Http\Request;
 
+use App\Application\Request\Command\PublishOpinionCommand;
 use yii\base\Model;
 
-final class PublishOpinionInput extends Model
+final class PublishOpinionRequest extends Model
 {
     public mixed $body = null;
     public mixed $lockVersion = null;
@@ -20,5 +21,10 @@ final class PublishOpinionInput extends Model
             ['lockVersion', 'required'],
             ['lockVersion', 'integer', 'min' => 1],
         ];
+    }
+
+    public function toCommand(int $requestId, int $actorId): PublishOpinionCommand
+    {
+        return new PublishOpinionCommand($requestId, $actorId, (string) $this->body, (int) $this->lockVersion);
     }
 }

--- a/backend/src/Infrastructure/Document/DocumentRepository.php
+++ b/backend/src/Infrastructure/Document/DocumentRepository.php
@@ -6,7 +6,6 @@ namespace App\Infrastructure\Document;
 
 use App\Domain\Request\AttachmentPolicy;
 use App\Domain\Request\ConcurrentRequestModification;
-use App\Domain\Request\OpinionPolicy;
 use App\Domain\Request\ReportDeletionPolicy;
 use App\Domain\Request\RequestNotFound;
 use App\Domain\Request\RequestStatus;
@@ -361,158 +360,6 @@ final class DocumentRepository
     }
 
     /** @return array<string, mixed> */
-    public function publishOpinion(
-        int $requestId,
-        int $actorId,
-        string $body,
-        int $expectedLockVersion,
-        OpinionPdfRenderer $renderer,
-    ): array {
-        $transaction = $this->db->beginTransaction();
-        $storageKey = null;
-        $temporaryPath = null;
-        try {
-            $request = $this->db->createCommand(
-                'SELECT r.number, r.status, r.lock_version AS lockVersion, r.product_name AS productName, '
-                . 'r.manufacturer, r.supplier, actor.display_name AS expertName, actor.position AS expertPosition, '
-                . 'actor.is_active AS actorIsActive, (expert.user_id = :expert_actor) AS isCurrentExpert '
-                . 'FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id '
-                . 'LEFT JOIN {{%request_assignments}} expert ON expert.request_id = r.id '
-                . "AND expert.assignment_type = 'expert' AND expert.valid_to IS NULL "
-                . 'WHERE r.id = :request_id FOR UPDATE',
-                [':request_id' => $requestId, ':actor_id' => $actorId, ':expert_actor' => $actorId],
-            )->queryOne();
-            if ($request === false) {
-                throw new RequestNotFound('Request not found');
-            }
-            (new OpinionPolicy())->assertCanPublish(
-                RequestStatus::from((string) $request['status']),
-                (bool) $request['actorIsActive'],
-                (bool) $request['isCurrentExpert'],
-            );
-            if ((int) $request['lockVersion'] !== $expectedLockVersion) {
-                throw new ConcurrentRequestModification();
-            }
-
-            $revision = (int) $this->db->createCommand(
-                'SELECT COALESCE(MAX(revision), 0) + 1 FROM {{%expert_opinions}} WHERE request_id = :request_id',
-                [':request_id' => $requestId],
-            )->queryScalar();
-            $pdf = $renderer->render([
-                'number' => (int) $request['number'],
-                'productName' => (string) $request['productName'],
-                'manufacturer' => (string) $request['manufacturer'],
-                'supplier' => (string) $request['supplier'],
-                'expertName' => (string) $request['expertName'],
-                'expertPosition' => (string) ($request['expertPosition'] ?: 'Эксперт'),
-                'body' => $body,
-                'date' => gmdate('d.m.Y'),
-            ]);
-            $temporaryPath = tempnam(sys_get_temp_dir(), 'opinion-');
-            if ($temporaryPath === false || file_put_contents($temporaryPath, $pdf, LOCK_EX) !== strlen($pdf)) {
-                throw new \RuntimeException('Cannot prepare opinion PDF.');
-            }
-            $storageKey = $this->storage->store($temporaryPath);
-            $sha256 = hash('sha256', $pdf);
-            $size = strlen($pdf);
-            $now = Clock::now();
-            $documentId = $this->findOrCreateOpinion($requestId, $actorId);
-            $this->db->createCommand()->insert('{{%request_document_versions}}', [
-                'document_id' => $documentId,
-                'version' => $revision,
-                'storage_key' => $storageKey,
-                'original_name' => sprintf('expert-opinion-%06d-v%d.pdf', (int) $request['number'], $revision),
-                'mime_type' => 'application/pdf',
-                'size_bytes' => $size,
-                'sha256' => $sha256,
-                'uploaded_by' => $actorId,
-                'created_at' => $now,
-            ])->execute();
-            $versionId = (int) $this->db->getLastInsertID();
-            $this->db->createCommand()->insert('{{%expert_opinions}}', [
-                'request_id' => $requestId,
-                'revision' => $revision,
-                'expert_id' => $actorId,
-                'body' => $body,
-                'document_version_id' => $versionId,
-                'created_at' => $now,
-            ])->execute();
-            $nextLockVersion = $expectedLockVersion + 1;
-            $updated = $this->db->createCommand()->update('{{%requests}}', [
-                'status' => RequestStatus::SecurityReview->value,
-                'lock_version' => $nextLockVersion,
-                'updated_at' => $now,
-            ], [
-                'id' => $requestId,
-                'status' => RequestStatus::OpinionPreparation->value,
-                'lock_version' => $expectedLockVersion,
-            ])->execute();
-            if ($updated !== 1) {
-                throw new ConcurrentRequestModification();
-            }
-            $this->db->createCommand()->insert('{{%request_transitions}}', [
-                'request_id' => $requestId,
-                'actor_id' => $actorId,
-                'from_status' => RequestStatus::OpinionPreparation->value,
-                'to_status' => RequestStatus::SecurityReview->value,
-                'action' => 'publish_opinion',
-                'rule_id' => 'DOC-007',
-                'created_at' => $now,
-            ])->execute();
-            $this->db->createCommand()->insert('{{%audit_events}}', [
-                'event_type' => 'request.opinion_published',
-                'entity_type' => 'request',
-                'entity_id' => $requestId,
-                'actor_id' => $actorId,
-                'rule_id' => 'DOC-007',
-                'payload_json' => ['revision' => $revision, 'document_version_id' => $versionId],
-                'created_at' => $now,
-            ])->execute();
-            // ТЗ 4.9: сотрудники СБ уведомляются о поступлении отчёта и
-            // заключения на контроль, письмо содержит активные ссылки на
-            // скачивание обоих документов без входа в портал.
-            $documentLinks = [['label' => 'заключение', 'documentVersionId' => $versionId]];
-            $reportVersionId = $this->latestDocumentVersionId($requestId, 'report');
-            if ($reportVersionId !== null) {
-                $documentLinks[] = ['label' => 'отчёт', 'documentVersionId' => $reportVersionId];
-            }
-            $outbox = new NotificationOutbox($this->db);
-            foreach ($this->activeUsersWithRoles(['security_officer']) as $officer) {
-                $outbox->enqueue(
-                    $requestId,
-                    'request.opinion_published',
-                    $officer['email'],
-                    $officer['name'],
-                    'Заключение поступило на контроль СБ',
-                    'Экспертное заключение опубликовано и ожидает проверки службы безопасности. '
-                    . 'Откройте заявку в портале.',
-                    $documentLinks,
-                );
-            }
-            $transaction->commit();
-
-            return [
-                'requestId' => $requestId,
-                'revision' => $revision,
-                'documentVersionId' => $versionId,
-                'status' => RequestStatus::SecurityReview->value,
-                'lockVersion' => $nextLockVersion,
-            ];
-        } catch (\Throwable $error) {
-            $transaction->rollBack();
-            if ($storageKey !== null) {
-                $this->storage->delete($storageKey);
-            }
-            throw $error;
-        } finally {
-            if ($temporaryPath !== null && is_file($temporaryPath)) {
-                // nosemgrep: php.lang.security.unlink-use.unlink-use -- tempnam generated this path
-                unlink($temporaryPath);
-            }
-        }
-    }
-
-    /** @return array<string, mixed> */
     public function findVersionForDownload(int $versionId, int $actorId): array
     {
         $version = $this->db->createCommand(
@@ -651,27 +498,6 @@ final class DocumentRepository
         ])->execute();
     }
 
-    public function recordRejectedOpinion(int $requestId, int $actorId, string $ruleId): void
-    {
-        $allowedReferences = $this->db->createCommand(
-            'SELECT 1 FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id '
-            . 'WHERE r.id = :request_id',
-            [':request_id' => $requestId, ':actor_id' => $actorId],
-        )->queryScalar();
-        if ($allowedReferences === false) {
-            return;
-        }
-        $this->db->createCommand()->insert('{{%audit_events}}', [
-            'event_type' => 'request.opinion_publish_rejected',
-            'entity_type' => 'request',
-            'entity_id' => $requestId,
-            'actor_id' => $actorId,
-            'rule_id' => $ruleId,
-            'payload_json' => ['outcome' => 'rejected'],
-            'created_at' => Clock::now(),
-        ])->execute();
-    }
-
     private function findOrCreateDocument(int $requestId, int $actorId, string $title): int
     {
         $documentId = $this->db->createCommand(
@@ -721,25 +547,6 @@ final class DocumentRepository
         return ['id' => (int) $this->db->getLastInsertID(), 'wasDeleted' => false];
     }
 
-    private function findOrCreateOpinion(int $requestId, int $actorId): int
-    {
-        $documentId = $this->db->createCommand(
-            "SELECT id FROM {{%request_documents}} WHERE request_id = :request_id AND document_type = 'opinion' FOR UPDATE",
-            [':request_id' => $requestId],
-        )->queryScalar();
-        if ($documentId !== false) {
-            return (int) $documentId;
-        }
-        $this->db->createCommand()->insert('{{%request_documents}}', [
-            'request_id' => $requestId,
-            'document_type' => 'opinion',
-            'title' => 'Экспертное заключение',
-            'created_by' => $actorId,
-            'created_at' => Clock::now(),
-        ])->execute();
-        return (int) $this->db->getLastInsertID();
-    }
-
     /**
      * @param list<string> $roleCodes
      * @return list<array{email: string, name: string}>
@@ -764,19 +571,5 @@ final class DocumentRepository
             . 'AND r.code IN (' . implode(',', $placeholders) . ')',
             $params,
         )->queryAll();
-    }
-
-    private function latestDocumentVersionId(int $requestId, string $documentType): ?int
-    {
-        $id = $this->db->createCommand(
-            'SELECT v.id FROM {{%request_document_versions}} v '
-            . 'JOIN {{%request_documents}} d ON d.id = v.document_id '
-            . 'WHERE d.request_id = :request_id AND d.document_type = :document_type '
-            . 'AND d.deleted_at IS NULL AND v.deleted_at IS NULL '
-            . 'ORDER BY v.version DESC LIMIT 1',
-            [':request_id' => $requestId, ':document_type' => $documentType],
-        )->queryScalar();
-
-        return $id === false ? null : (int) $id;
     }
 }

--- a/backend/src/Infrastructure/Document/OpinionRendererAdapter.php
+++ b/backend/src/Infrastructure/Document/OpinionRendererAdapter.php
@@ -1,0 +1,29 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Document;
+
+use App\Application\Request\Port\OpinionRenderer;
+use App\Application\Request\PublishOpinionSnapshot;
+
+final readonly class OpinionRendererAdapter implements OpinionRenderer
+{
+    public function __construct(private OpinionPdfRenderer $renderer = new OpinionPdfRenderer())
+    {
+    }
+
+    public function render(PublishOpinionSnapshot $snapshot, string $body): string
+    {
+        return $this->renderer->render([
+            'number' => $snapshot->number,
+            'productName' => $snapshot->productName,
+            'manufacturer' => $snapshot->manufacturer,
+            'supplier' => $snapshot->supplier,
+            'expertName' => $snapshot->expertName,
+            'expertPosition' => $snapshot->expertPosition,
+            'body' => $body,
+            'date' => gmdate('d.m.Y'),
+        ]);
+    }
+}

--- a/backend/src/Infrastructure/Persistence/Request/PublishOpinionPersistenceAdapter.php
+++ b/backend/src/Infrastructure/Persistence/Request/PublishOpinionPersistenceAdapter.php
@@ -1,0 +1,222 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Persistence\Request;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\Port\PublishOpinionGateway;
+use App\Application\Request\PublishOpinionSnapshot;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\RequestStatus;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Document\DocumentStorage;
+use App\Infrastructure\Notification\NotificationOutbox;
+use yii\db\Connection;
+
+final readonly class PublishOpinionPersistenceAdapter implements PublishOpinionGateway
+{
+    public function __construct(private Connection $db, private DocumentStorage $storage)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        $transaction = $this->db->beginTransaction();
+        $storageCheckpoint = DocumentStorage::writeCheckpoint();
+        try {
+            $result = $operation();
+            $transaction->commit();
+            DocumentStorage::discardWritesSince($storageCheckpoint);
+            return $result;
+        } catch (\Throwable $error) {
+            $transaction->rollBack();
+            DocumentStorage::rollbackWritesSince($storageCheckpoint);
+            throw $error;
+        }
+    }
+
+    public function snapshotForUpdate(int $requestId, int $actorId): ?PublishOpinionSnapshot
+    {
+        $row = $this->db->createCommand(
+            'SELECT r.number, r.status, r.lock_version AS lockVersion, r.product_name AS productName, '
+            . 'r.manufacturer, r.supplier, actor.display_name AS expertName, actor.position AS expertPosition, '
+            . 'actor.is_active AS actorIsActive, (expert.user_id = :expert_actor) AS isCurrentExpert '
+            . 'FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id '
+            . 'LEFT JOIN {{%request_assignments}} expert ON expert.request_id = r.id '
+            . "AND expert.assignment_type = 'expert' AND expert.valid_to IS NULL "
+            . 'WHERE r.id = :request_id FOR UPDATE',
+            [':request_id' => $requestId, ':actor_id' => $actorId, ':expert_actor' => $actorId],
+        )->queryOne();
+        if ($row === false) {
+            return null;
+        }
+
+        return new PublishOpinionSnapshot(
+            (int) $row['number'],
+            RequestStatus::from((string) $row['status']),
+            (int) $row['lockVersion'],
+            (string) $row['productName'],
+            (string) $row['manufacturer'],
+            (string) $row['supplier'],
+            (string) $row['expertName'],
+            (string) ($row['expertPosition'] ?: 'Эксперт'),
+            (bool) $row['actorIsActive'],
+            (bool) $row['isCurrentExpert'],
+        );
+    }
+
+    public function nextRevision(int $requestId): int
+    {
+        return (int) $this->db->createCommand(
+            'SELECT COALESCE(MAX(revision), 0) + 1 FROM {{%expert_opinions}} WHERE request_id = :request_id',
+            [':request_id' => $requestId],
+        )->queryScalar();
+    }
+
+    public function persistPublication(
+        PublishOpinionCommand $command,
+        PublishOpinionSnapshot $snapshot,
+        int $revision,
+        string $pdf,
+    ): int {
+        $temporaryPath = tempnam(sys_get_temp_dir(), 'opinion-');
+        $storageKey = null;
+        try {
+            if ($temporaryPath === false || file_put_contents($temporaryPath, $pdf, LOCK_EX) !== strlen($pdf)) {
+                throw new \RuntimeException('Cannot prepare opinion PDF.');
+            }
+            $storageKey = $this->storage->store($temporaryPath);
+            $now = Clock::now();
+            $documentId = $this->findOrCreateOpinion($command->requestId, $command->actorId, $now);
+            $this->db->createCommand()->insert('{{%request_document_versions}}', [
+                'document_id' => $documentId,
+                'version' => $revision,
+                'storage_key' => $storageKey,
+                'original_name' => sprintf('expert-opinion-%06d-v%d.pdf', $snapshot->number, $revision),
+                'mime_type' => 'application/pdf',
+                'size_bytes' => strlen($pdf),
+                'sha256' => hash('sha256', $pdf),
+                'uploaded_by' => $command->actorId,
+                'created_at' => $now,
+            ])->execute();
+            $versionId = (int) $this->db->getLastInsertID();
+            $this->persistBusinessRecords($command, $revision, $versionId, $now);
+            $this->enqueueNotifications($command->requestId, $versionId);
+            return $versionId;
+        } catch (\Throwable $error) {
+            if ($storageKey !== null) {
+                $this->storage->delete($storageKey);
+            }
+            throw $error;
+        } finally {
+            if ($temporaryPath !== false && is_file($temporaryPath)) {
+                // nosemgrep: php.lang.security.unlink-use.unlink-use -- tempnam generated this path
+                unlink($temporaryPath);
+            }
+        }
+    }
+
+    public function recordRejected(int $requestId, int $actorId, string $ruleId): void
+    {
+        $allowed = $this->db->createCommand(
+            'SELECT 1 FROM {{%requests}} r JOIN {{%users}} actor ON actor.id = :actor_id WHERE r.id = :request_id',
+            [':request_id' => $requestId, ':actor_id' => $actorId],
+        )->queryScalar();
+        if ($allowed === false) {
+            return;
+        }
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.opinion_publish_rejected', 'entity_type' => 'request', 'entity_id' => $requestId,
+            'actor_id' => $actorId, 'rule_id' => $ruleId,
+            'payload_json' => ['outcome' => 'rejected'], 'created_at' => Clock::now(),
+        ])->execute();
+    }
+
+    private function persistBusinessRecords(PublishOpinionCommand $command, int $revision, int $versionId, string $now): void
+    {
+        $this->db->createCommand()->insert('{{%expert_opinions}}', [
+            'request_id' => $command->requestId, 'revision' => $revision, 'expert_id' => $command->actorId,
+            'body' => $command->body, 'document_version_id' => $versionId, 'created_at' => $now,
+        ])->execute();
+        $nextLockVersion = $command->expectedLockVersion + 1;
+        $updated = $this->db->createCommand()->update('{{%requests}}', [
+            'status' => RequestStatus::SecurityReview->value, 'lock_version' => $nextLockVersion, 'updated_at' => $now,
+        ], [
+            'id' => $command->requestId, 'status' => RequestStatus::OpinionPreparation->value,
+            'lock_version' => $command->expectedLockVersion,
+        ])->execute();
+        if ($updated !== 1) {
+            throw new ConcurrentRequestModification();
+        }
+        $this->db->createCommand()->insert('{{%request_transitions}}', [
+            'request_id' => $command->requestId, 'actor_id' => $command->actorId,
+            'from_status' => RequestStatus::OpinionPreparation->value,
+            'to_status' => RequestStatus::SecurityReview->value, 'action' => 'publish_opinion',
+            'rule_id' => 'DOC-007', 'created_at' => $now,
+        ])->execute();
+        $this->db->createCommand()->insert('{{%audit_events}}', [
+            'event_type' => 'request.opinion_published', 'entity_type' => 'request',
+            'entity_id' => $command->requestId, 'actor_id' => $command->actorId, 'rule_id' => 'DOC-007',
+            'payload_json' => ['revision' => $revision, 'document_version_id' => $versionId], 'created_at' => $now,
+        ])->execute();
+    }
+
+    private function enqueueNotifications(int $requestId, int $versionId): void
+    {
+        $links = [['label' => 'заключение', 'documentVersionId' => $versionId]];
+        $reportVersionId = $this->latestDocumentVersionId($requestId, 'report');
+        if ($reportVersionId !== null) {
+            $links[] = ['label' => 'отчёт', 'documentVersionId' => $reportVersionId];
+        }
+        $outbox = new NotificationOutbox($this->db);
+        foreach ($this->activeSecurityOfficers() as $officer) {
+            $outbox->enqueue(
+                $requestId,
+                'request.opinion_published',
+                $officer['email'],
+                $officer['name'],
+                'Заключение поступило на контроль СБ',
+                'Экспертное заключение опубликовано и ожидает проверки службы безопасности. Откройте заявку в портале.',
+                $links,
+            );
+        }
+    }
+
+    private function findOrCreateOpinion(int $requestId, int $actorId, string $now): int
+    {
+        $id = $this->db->createCommand(
+            "SELECT id FROM {{%request_documents}} WHERE request_id = :request_id AND document_type = 'opinion' FOR UPDATE",
+            [':request_id' => $requestId],
+        )->queryScalar();
+        if ($id !== false) {
+            return (int) $id;
+        }
+        $this->db->createCommand()->insert('{{%request_documents}}', [
+            'request_id' => $requestId, 'document_type' => 'opinion', 'title' => 'Экспертное заключение',
+            'created_by' => $actorId, 'created_at' => $now,
+        ])->execute();
+        return (int) $this->db->getLastInsertID();
+    }
+
+    /** @return list<array{email: string, name: string}> */
+    private function activeSecurityOfficers(): array
+    {
+        return $this->db->createCommand(
+            'SELECT DISTINCT TRIM(u.email) AS email, u.display_name AS name FROM {{%users}} u '
+            . 'JOIN {{%user_roles}} ur ON ur.user_id = u.id JOIN {{%roles}} r ON r.id = ur.role_id '
+            . "WHERE u.is_active = 1 AND u.email IS NOT NULL AND TRIM(u.email) != '' AND r.code = 'security_officer'",
+        )->queryAll();
+    }
+
+    private function latestDocumentVersionId(int $requestId, string $documentType): ?int
+    {
+        $id = $this->db->createCommand(
+            'SELECT v.id FROM {{%request_document_versions}} v JOIN {{%request_documents}} d ON d.id = v.document_id '
+            . 'WHERE d.request_id = :request_id AND d.document_type = :document_type '
+            . 'AND d.deleted_at IS NULL AND v.deleted_at IS NULL ORDER BY v.version DESC LIMIT 1',
+            [':request_id' => $requestId, ':document_type' => $documentType],
+        )->queryScalar();
+        return $id === false ? null : (int) $id;
+    }
+}

--- a/backend/tests/Integration/Request/ControlledPublishOpinionAuditFailureCommand.php
+++ b/backend/tests/Integration/Request/ControlledPublishOpinionAuditFailureCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use yii\db\Command;
+
+final class ControlledPublishOpinionAuditFailureCommand extends Command
+{
+    /** @param array<string, mixed>|\yii\db\Query $columns */
+    public function insert($table, $columns)
+    {
+        if (
+            $table === '{{%audit_events}}'
+            && is_array($columns)
+            && ($columns['event_type'] ?? null) === 'request.opinion_published'
+        ) {
+            throw new \RuntimeException('controlled publish opinion audit failure');
+        }
+        return parent::insert($table, $columns);
+    }
+}

--- a/backend/tests/Integration/Request/PublishOpinionTest.php
+++ b/backend/tests/Integration/Request/PublishOpinionTest.php
@@ -1,0 +1,250 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Request;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\UseCase\PublishOpinion;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\OpinionDenied;
+use App\Infrastructure\Clock;
+use App\Infrastructure\Document\DocumentStorage;
+use App\Infrastructure\Document\OpinionRendererAdapter;
+use App\Infrastructure\Persistence\Request\PublishOpinionPersistenceAdapter;
+use App\Infrastructure\Persistence\Request\RequestCreationPersistenceAdapter;
+use App\Http\Request\CreateRequest;
+use Tests\Integration\IntegrationTestCase;
+
+final class PublishOpinionTest extends IntegrationTestCase
+{
+    private ?string $storageRoot = null;
+
+    protected function tearDown(): void
+    {
+        try {
+            if ($this->storageRoot !== null) {
+                $this->removeStorageTree($this->storageRoot);
+            }
+        } finally {
+            parent::tearDown();
+        }
+    }
+
+    public function testPublicationPersistsPdfTransitionAuditAndDeduplicatedSecurityNotifications(): void
+    {
+        [$requestId, $expertId, $lockVersion] = $this->publicationFixture('success');
+        $officer = $this->createUser('opinion-officer', 'Сотрудник СБ', 'security@example.invalid');
+        $this->grantRole($officer, 'security_officer');
+        $this->grantRole($officer, 'administrator');
+
+        $result = $this->useCase()->execute(new PublishOpinionCommand(
+            $requestId,
+            $expertId,
+            'Испытания завершены, требования выполнены.',
+            $lockVersion,
+        ));
+
+        self::assertSame('security_review', $result->status->value);
+        self::assertSame($lockVersion + 1, $result->lockVersion);
+        $persistedRequest = $this->db()->createCommand(
+            'SELECT status, lock_version FROM {{%requests}} WHERE id = :id',
+            [':id' => $requestId],
+        )->queryOne();
+        self::assertSame('security_review', $persistedRequest['status']);
+        self::assertSame($lockVersion + 1, (int) $persistedRequest['lock_version']);
+        $version = $this->db()->createCommand(
+            'SELECT original_name, mime_type, storage_key, size_bytes FROM {{%request_document_versions}} WHERE id = :id',
+            [':id' => $result->documentVersionId],
+        )->queryOne();
+        self::assertMatchesRegularExpression('/^expert-opinion-\d{6}-v1\.pdf$/', (string) $version['original_name']);
+        self::assertSame('application/pdf', $version['mime_type']);
+        self::assertGreaterThan(100, (int) $version['size_bytes']);
+        self::assertFileExists($this->storage()->path((string) $version['storage_key']));
+        self::assertSame(1, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND event_type = 'request.opinion_published' AND rule_id = 'DOC-007'",
+            [':id' => $requestId],
+        ));
+        self::assertSame(1, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id "
+            . "AND event_type = 'request.opinion_published' AND recipient_email = 'security@example.invalid'",
+            [':id' => $requestId],
+        ));
+    }
+
+    public function testStalePublicationCreatesNoOpinionFileOrSuccessSideEffects(): void
+    {
+        [$requestId, $expertId, $lockVersion] = $this->publicationFixture('stale');
+
+        try {
+            $this->useCase()->execute(new PublishOpinionCommand($requestId, $expertId, str_repeat('Тест ', 3), $lockVersion - 1));
+            self::fail('Expected stale publication conflict.');
+        } catch (ConcurrentRequestModification) {
+            self::assertSame([], $this->storedFiles());
+            $persistedRequest = $this->db()->createCommand(
+                'SELECT status, lock_version FROM {{%requests}} WHERE id = :id',
+                [':id' => $requestId],
+            )->queryOne();
+            self::assertSame('opinion_preparation', $persistedRequest['status']);
+            self::assertSame($lockVersion, (int) $persistedRequest['lock_version']);
+            self::assertSame(0, (int) $this->scalar(
+                'SELECT COUNT(*) FROM {{%expert_opinions}} WHERE request_id = :id',
+                [':id' => $requestId],
+            ));
+            self::assertSame(0, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND event_type = 'request.opinion_published'",
+                [':id' => $requestId],
+            ));
+            self::assertSame(0, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id AND event_type = 'request.opinion_published'",
+                [':id' => $requestId],
+            ));
+        }
+    }
+
+    public function testUnassignedExpertCreatesNoOpinionOrSuccessAudit(): void
+    {
+        [$requestId, , $lockVersion] = $this->publicationFixture('denied');
+        $outsider = $this->createUser('opinion-outsider', 'Другой эксперт');
+        $this->grantRole($outsider, 'expert');
+
+        try {
+            $this->useCase()->execute(new PublishOpinionCommand($requestId, $outsider, str_repeat('Тест ', 3), $lockVersion));
+            self::fail('Expected publication denial.');
+        } catch (OpinionDenied $error) {
+            self::assertSame('DOC-005', $error->ruleId);
+            self::assertSame([], $this->storedFiles());
+            $persistedRequest = $this->db()->createCommand(
+                'SELECT status, lock_version FROM {{%requests}} WHERE id = :id',
+                [':id' => $requestId],
+            )->queryOne();
+            self::assertSame('opinion_preparation', $persistedRequest['status']);
+            self::assertSame($lockVersion, (int) $persistedRequest['lock_version']);
+            self::assertSame(0, (int) $this->scalar(
+                'SELECT COUNT(*) FROM {{%expert_opinions}} WHERE request_id = :id',
+                [':id' => $requestId],
+            ));
+            self::assertSame(0, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND event_type = 'request.opinion_published'",
+                [':id' => $requestId],
+            ));
+            self::assertSame(0, (int) $this->scalar(
+                "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id AND event_type = 'request.opinion_published'",
+                [':id' => $requestId],
+            ));
+        }
+    }
+
+    public function testAuditFailureRollsBackBusinessMutationOutboxAndStoredPdf(): void
+    {
+        [$requestId, $expertId, $lockVersion] = $this->publicationFixture('audit-failure');
+        $originalCommandClass = $this->db()->commandClass;
+        $this->db()->commandClass = ControlledPublishOpinionAuditFailureCommand::class;
+        try {
+            $this->useCase()->execute(new PublishOpinionCommand(
+                $requestId,
+                $expertId,
+                'Заключение для проверки атомарного отката.',
+                $lockVersion,
+            ));
+            self::fail('Expected controlled audit failure.');
+        } catch (\RuntimeException $error) {
+            self::assertStringContainsString('controlled publish opinion audit failure', $error->getMessage());
+        } finally {
+            $this->db()->commandClass = $originalCommandClass;
+        }
+
+        self::assertSame([], $this->storedFiles());
+        self::assertSame(0, (int) $this->scalar(
+            'SELECT COUNT(*) FROM {{%expert_opinions}} WHERE request_id = :id',
+            [':id' => $requestId],
+        ));
+        $persistedRequest = $this->db()->createCommand(
+            'SELECT status, lock_version FROM {{%requests}} WHERE id = :id',
+            [':id' => $requestId],
+        )->queryOne();
+        self::assertSame('opinion_preparation', $persistedRequest['status']);
+        self::assertSame($lockVersion, (int) $persistedRequest['lock_version']);
+        self::assertSame(0, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%audit_events}} WHERE entity_id = :id AND event_type = 'request.opinion_published'",
+            [':id' => $requestId],
+        ));
+        self::assertSame(0, (int) $this->scalar(
+            "SELECT COUNT(*) FROM {{%notification_outbox}} WHERE request_id = :id AND event_type = 'request.opinion_published'",
+            [':id' => $requestId],
+        ));
+    }
+
+    /** @return array{int, int, int} */
+    private function publicationFixture(string $marker): array
+    {
+        $initiator = $this->createUser("opinion-initiator-{$marker}", 'Инициатор');
+        $expert = $this->createUser("opinion-expert-{$marker}", 'Главный эксперт');
+        $this->grantRole($expert, 'expert');
+        $now = Clock::now();
+        $input = new CreateRequest();
+        $input->setAttributes([
+            'productName' => "Лифт {$marker}", 'manufacturer' => 'Завод', 'supplier' => 'Поставщик',
+            'sampleQuantity' => 1, 'testMethod' => 'Методика',
+        ]);
+        $created = (new \App\Application\Request\UseCase\CreateRequest(
+            new RequestCreationPersistenceAdapter($this->db()),
+        ))->execute($input->toCommand($initiator));
+        $requestId = (int) $created->toArray()['id'];
+        $this->db()->createCommand()->update('{{%requests}}', [
+            'status' => 'opinion_preparation', 'lock_version' => 4, 'updated_at' => $now,
+        ], ['id' => $requestId])->execute();
+        $this->db()->createCommand()->insert('{{%request_assignments}}', [
+            'request_id' => $requestId, 'assignment_type' => 'expert', 'user_id' => $expert,
+            'assigned_by' => $initiator, 'valid_from' => $now,
+        ])->execute();
+        return [$requestId, $expert, 4];
+    }
+
+    private function useCase(): PublishOpinion
+    {
+        return new PublishOpinion(
+            new PublishOpinionPersistenceAdapter($this->db(), $this->storage()),
+            new OpinionRendererAdapter(),
+        );
+    }
+
+    private function storage(): DocumentStorage
+    {
+        $this->storageRoot ??= sys_get_temp_dir() . '/ic-opinion-' . bin2hex(random_bytes(8));
+        if (!is_dir($this->storageRoot)) {
+            mkdir($this->storageRoot, 0700, true);
+        }
+        return new DocumentStorage($this->storageRoot);
+    }
+
+    /** @return list<string> */
+    private function storedFiles(): array
+    {
+        if ($this->storageRoot === null || !is_dir($this->storageRoot)) {
+            return [];
+        }
+        $files = [];
+        foreach (new \RecursiveIteratorIterator(new \RecursiveDirectoryIterator($this->storageRoot)) as $file) {
+            if ($file->isFile()) {
+                $files[] = $file->getPathname();
+            }
+        }
+        return $files;
+    }
+
+    private function removeStorageTree(string $root): void
+    {
+        if (!is_dir($root)) {
+            return;
+        }
+        $iterator = new \RecursiveIteratorIterator(
+            new \RecursiveDirectoryIterator($root, \FilesystemIterator::SKIP_DOTS),
+            \RecursiveIteratorIterator::CHILD_FIRST,
+        );
+        foreach ($iterator as $entry) {
+            $entry->isDir() ? rmdir($entry->getPathname()) : unlink($entry->getPathname());
+        }
+        rmdir($root);
+    }
+}

--- a/backend/tests/Unit/Application/Request/InMemoryPublishOpinionGateway.php
+++ b/backend/tests/Unit/Application/Request/InMemoryPublishOpinionGateway.php
@@ -1,0 +1,49 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Request;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\Port\PublishOpinionGateway;
+use App\Application\Request\PublishOpinionSnapshot;
+
+final class InMemoryPublishOpinionGateway implements PublishOpinionGateway
+{
+    public int $transactionCount = 0;
+    public ?string $persistedPdf = null;
+
+    public function __construct(private readonly ?PublishOpinionSnapshot $snapshot)
+    {
+    }
+
+    public function transactional(callable $operation): mixed
+    {
+        ++$this->transactionCount;
+        return $operation();
+    }
+
+    public function snapshotForUpdate(int $requestId, int $actorId): ?PublishOpinionSnapshot
+    {
+        return $this->snapshot;
+    }
+
+    public function nextRevision(int $requestId): int
+    {
+        return 2;
+    }
+
+    public function persistPublication(
+        PublishOpinionCommand $command,
+        PublishOpinionSnapshot $snapshot,
+        int $revision,
+        string $pdf,
+    ): int {
+        $this->persistedPdf = $pdf;
+        return 73;
+    }
+
+    public function recordRejected(int $requestId, int $actorId, string $ruleId): void
+    {
+    }
+}

--- a/backend/tests/Unit/Application/Request/PublishOpinionTest.php
+++ b/backend/tests/Unit/Application/Request/PublishOpinionTest.php
@@ -1,0 +1,94 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Request;
+
+use App\Application\Request\Command\PublishOpinionCommand;
+use App\Application\Request\PublishOpinionSnapshot;
+use App\Application\Request\UseCase\PublishOpinion;
+use App\Domain\Request\ConcurrentRequestModification;
+use App\Domain\Request\OpinionDenied;
+use App\Domain\Request\RequestStatus;
+use PHPUnit\Framework\TestCase;
+
+final class PublishOpinionTest extends TestCase
+{
+    public function testPublishesRenderedOpinionAndReturnsTransitionResult(): void
+    {
+        $gateway = new InMemoryPublishOpinionGateway($this->snapshot());
+        $renderer = new RecordingOpinionRenderer('%PDF opinion');
+        $command = new PublishOpinionCommand(41, 7, 'Испытания пройдены успешно.', 3);
+
+        $result = (new PublishOpinion($gateway, $renderer))->execute($command);
+
+        self::assertSame([
+            'requestId' => 41, 'revision' => 2, 'documentVersionId' => 73,
+            'status' => 'security_review', 'lockVersion' => 4,
+        ], $result->toArray());
+        self::assertSame('Испытания пройдены успешно.', $renderer->body);
+        self::assertSame('%PDF opinion', $gateway->persistedPdf);
+        self::assertSame(1, $gateway->transactionCount);
+    }
+
+    public function testUnauthorizedActorIsRejectedBeforeRenderingOrPersistence(): void
+    {
+        $gateway = new InMemoryPublishOpinionGateway($this->snapshot(isCurrentExpert: false));
+        $renderer = new RecordingOpinionRenderer('%PDF opinion');
+
+        try {
+            (new PublishOpinion($gateway, $renderer))->execute(new PublishOpinionCommand(41, 8, str_repeat('x', 10), 3));
+            self::fail('Expected publication denial.');
+        } catch (OpinionDenied $error) {
+            self::assertSame('DOC-005', $error->ruleId);
+            self::assertNull($renderer->body);
+            self::assertNull($gateway->persistedPdf);
+        }
+    }
+
+    public function testInvalidStateIsRejectedBeforeRenderingOrPersistence(): void
+    {
+        $gateway = new InMemoryPublishOpinionGateway($this->snapshot(status: RequestStatus::InProgress));
+        $renderer = new RecordingOpinionRenderer('%PDF opinion');
+
+        $this->expectException(OpinionDenied::class);
+        try {
+            (new PublishOpinion($gateway, $renderer))->execute(new PublishOpinionCommand(41, 7, str_repeat('x', 10), 3));
+        } finally {
+            self::assertNull($renderer->body);
+            self::assertNull($gateway->persistedPdf);
+        }
+    }
+
+    public function testStaleVersionIsRejectedBeforeRenderingOrPersistence(): void
+    {
+        $gateway = new InMemoryPublishOpinionGateway($this->snapshot());
+        $renderer = new RecordingOpinionRenderer('%PDF opinion');
+
+        $this->expectException(ConcurrentRequestModification::class);
+        try {
+            (new PublishOpinion($gateway, $renderer))->execute(new PublishOpinionCommand(41, 7, str_repeat('x', 10), 2));
+        } finally {
+            self::assertNull($renderer->body);
+            self::assertNull($gateway->persistedPdf);
+        }
+    }
+
+    private function snapshot(
+        RequestStatus $status = RequestStatus::OpinionPreparation,
+        bool $isCurrentExpert = true,
+    ): PublishOpinionSnapshot {
+        return new PublishOpinionSnapshot(
+            123,
+            $status,
+            3,
+            'Лифт',
+            'Завод',
+            'Поставщик',
+            'Эксперт',
+            'Инженер',
+            true,
+            $isCurrentExpert,
+        );
+    }
+}

--- a/backend/tests/Unit/Application/Request/RecordingOpinionRenderer.php
+++ b/backend/tests/Unit/Application/Request/RecordingOpinionRenderer.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Application\Request;
+
+use App\Application\Request\Port\OpinionRenderer;
+use App\Application\Request\PublishOpinionSnapshot;
+
+final class RecordingOpinionRenderer implements OpinionRenderer
+{
+    public ?string $body = null;
+
+    public function __construct(private readonly string $pdf)
+    {
+    }
+
+    public function render(PublishOpinionSnapshot $snapshot, string $body): string
+    {
+        $this->body = $body;
+        return $this->pdf;
+    }
+}

--- a/backend/tests/Unit/Http/Request/PublishOpinionRequestTest.php
+++ b/backend/tests/Unit/Http/Request/PublishOpinionRequestTest.php
@@ -2,17 +2,17 @@
 
 declare(strict_types=1);
 
-namespace Tests\Unit\Application\Request;
+namespace Tests\Unit\Http\Request;
 
-use App\Application\Request\PublishOpinionInput;
+use App\Http\Request\PublishOpinionRequest;
 use PHPUnit\Framework\Attributes\DataProvider;
 use PHPUnit\Framework\TestCase;
 
-final class PublishOpinionInputTest extends TestCase
+final class PublishOpinionRequestTest extends TestCase
 {
     public function testAcceptsValidOpinion(): void
     {
-        $input = new PublishOpinionInput();
+        $input = new PublishOpinionRequest();
         $input->load(['body' => 'Образец соответствует требованиям.', 'lockVersion' => 5], '');
 
         self::assertTrue($input->validate());
@@ -22,7 +22,7 @@ final class PublishOpinionInputTest extends TestCase
     #[DataProvider('invalidData')]
     public function testRejectsInvalidInput(array $data): void
     {
-        $input = new PublishOpinionInput();
+        $input = new PublishOpinionRequest();
         $input->load($data, '');
 
         self::assertFalse($input->validate());

--- a/backend/tools/architecture-baseline.php
+++ b/backend/tools/architecture-baseline.php
@@ -17,7 +17,6 @@ return [
         'backend/src/Application/Identity/LoginInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Identity/RevokeRoleInput.php' => ['yii\\base\\Model'],
         'backend/src/Application/Request/ListRequestsInput.php' => ['yii\\base\\Model'],
-        'backend/src/Application/Request/PublishOpinionInput.php' => ['yii\\base\\Model'],
         'backend/src/Http/Controller/AdminController.php' => [
             'App\\Infrastructure\\Admin\\AuditQuery',
             'App\\Infrastructure\\Admin\\NotificationQuery',
@@ -63,15 +62,14 @@ return [
             'App\\Infrastructure\\Document\\DocumentRepository',
             'App\\Infrastructure\\Document\\DocumentStorage',
             'App\\Infrastructure\\Document\\OfficeDocumentInspector',
-            'App\\Infrastructure\\Document\\OpinionPdfRenderer',
             'App\\Infrastructure\\Document\\TestActDocumentGenerator',
             'App\\Infrastructure\\Identity\\CurrentUser',
             'App\\Infrastructure\\Request\\RequestQuery',
         ],
     ],
     'files' => [
-        'backend/src/Http/Controller/RequestController.php' => 861,
-        'backend/src/Infrastructure/Document/DocumentRepository.php' => 782,
+        'backend/src/Http/Controller/RequestController.php' => 856,
+        'backend/src/Infrastructure/Document/DocumentRepository.php' => 575,
         'backend/src/Infrastructure/Request/RequestQuery.php' => 645,
         'frontend/src/components/RequestDetails.vue' => 1272,
         'frontend/src/components/RequestRegistry.vue' => 847,
@@ -85,7 +83,6 @@ return [
         ],
         'backend/src/Infrastructure/Document/DocumentRepository.php' => [
             'DocumentRepository::deleteReport' => 92,
-            'DocumentRepository::publishOpinion' => 150,
             'DocumentRepository::uploadReport' => 159,
         ],
         'backend/src/Infrastructure/Document/TestActDocumentTemplate.php' => [


### PR DESCRIPTION
## Summary

Extracts the PublishOpinion workflow from DocumentRepository into a dedicated vertical slice.

The HTTP flow is now:

PublishOpinionRequest
→ PublishOpinionCommand
→ PublishOpinion
→ OpinionRenderer / PublishOpinionGateway
→ infrastructure adapters

`DocumentRepository::publishOpinion()` and its opinion-only helpers are removed.

## Why

The previous ~150-line method combined:

- authorization and workflow;
- request locking and optimistic concurrency;
- PDF rendering;
- filesystem persistence and compensation;
- database persistence;
- audit;
- notification outbox.

This change makes the business sequence explicit while keeping technical atomicity in Infrastructure.

## Behavior preserved

- active expert authorization;
- `opinion_preparation → security_review`;
- optimistic-lock semantics;
- `SELECT ... FOR UPDATE`;
- existing PDF renderer/content/filename/MIME;
- filesystem cleanup on rollback/commit failure;
- transition and audit semantics including `DOC-007`;
- denied audit `request.opinion_publish_rejected`;
- security officer notification recipients, deduplication and links;
- HTTP endpoint, validation, error mappings and response shape.

## Regression coverage

Covers:

- successful publication including PDF, transition, audit and outbox;
- stale optimistic-lock conflict;
- unauthorized publication;
- failure after PDF storage with DB rollback and orphan-file cleanup.

## Scope

Not changed:

- report upload/delete;
- generic attachments/downloads;
- Request read-side;
- other write slices;
- RequestController decomposition;
- generic repository/document/transaction abstractions.

## Verification

- `make check` — 463 backend unit tests and 264 frontend tests;
- `make e2e` — 300 integration tests / 1900 assertions and 16 Playwright tests;
- `make coverage` — 763 backend tests, 95.53% Domain/Application coverage;
- architecture guard;
- `git diff --check`;
- `$pr-review`.

All pass locally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added expert opinion publishing with generated PDF documents.
  - Published opinions now update request status, revision, and lock version.
  - Added audit records and security notifications for successful publications.
  - Added rejection handling for unauthorized experts, invalid request states, and outdated versions.
- **Bug Fixes**
  - Failed publications now roll back related documents, audit records, notifications, and request changes to prevent partial updates.
  - Prevented duplicate security notifications for repeated successful publications.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->