### PR TITLE
feat(observability): add monitoring foundation

### DIFF
--- a/compose.observability.yml
+++ b/compose.observability.yml
@@ -1,0 +1,127 @@
+x-observability-logging: &observability-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
+services:
+  grafana:
+    image: docker.io/grafana/grafana:12.1.0
+    environment:
+      GF_SECURITY_ADMIN_USER: ${GRAFANA_ADMIN_USER:-admin}
+      GF_SECURITY_ADMIN_PASSWORD: ${GRAFANA_ADMIN_PASSWORD:?Set GRAFANA_ADMIN_PASSWORD in the deployment env file}
+      GF_USERS_ALLOW_SIGN_UP: "false"
+      GF_AUTH_ANONYMOUS_ENABLED: "false"
+      GF_ANALYTICS_REPORTING_ENABLED: "false"
+      GF_ANALYTICS_CHECK_FOR_UPDATES: "false"
+      GF_ANALYTICS_CHECK_FOR_PLUGIN_UPDATES: "false"
+      GF_PLUGINS_PREINSTALL_DISABLED: "true"
+    ports:
+      - "127.0.0.1:${GRAFANA_PORT:-3000}:3000"
+    volumes:
+      - grafana-data:/var/lib/grafana
+      - ./observability/grafana/provisioning/datasources:/etc/grafana/provisioning/datasources:ro
+      - ./observability/grafana/provisioning/dashboards:/etc/grafana/provisioning/dashboards:ro
+      - ./observability/grafana/dashboards:/var/lib/grafana/dashboards:ro
+    depends_on:
+      prometheus:
+        condition: service_healthy
+      loki:
+        condition: service_healthy
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3000/api/health"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 30s
+    logging: *observability-logging
+    restart: unless-stopped
+
+  prometheus:
+    image: docker.io/prom/prometheus:v3.5.0
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --storage.tsdb.retention.time=${PROMETHEUS_RETENTION:-15d}
+      - --storage.tsdb.retention.size=${PROMETHEUS_RETENTION_SIZE:-10GB}
+    volumes:
+      - prometheus-data:/prometheus
+      - ./observability/prometheus:/etc/prometheus:ro
+    healthcheck:
+      test: ["CMD", "wget", "-q", "--spider", "http://127.0.0.1:9090/-/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    logging: *observability-logging
+    restart: unless-stopped
+
+  loki:
+    image: docker.io/grafana/loki:3.5.3
+    command: ["-config.file=/etc/loki/config.yml"]
+    volumes:
+      - loki-data:/loki
+      - ./observability/loki/config.yml:/etc/loki/config.yml:ro
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3100/ready"]
+      interval: 30s
+      timeout: 5s
+      retries: 5
+      start_period: 20s
+    logging: *observability-logging
+    restart: unless-stopped
+
+  alloy:
+    image: docker.io/grafana/alloy:v1.10.0
+    command:
+      - run
+      - --server.http.listen-addr=0.0.0.0:12345
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - alloy-data:/var/lib/alloy/data
+      - ./observability/alloy/config.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    depends_on:
+      loki:
+        condition: service_healthy
+    logging: *observability-logging
+    restart: unless-stopped
+
+  node-exporter:
+    image: quay.io/prometheus/node-exporter:v1.9.1
+    command:
+      - --path.rootfs=/host
+      - --collector.filesystem.mount-points-exclude=^/(dev|proc|sys|var/lib/docker/.+|var/lib/containers/.+|run/desktop/.+|parent-distro/.+|mnt/host/wsl/.+|mnt/wsl/.+)($$|/)
+    pid: host
+    volumes:
+      - /:/host:ro
+    logging: *observability-logging
+    restart: unless-stopped
+
+  cadvisor:
+    image: gcr.io/cadvisor/cadvisor:v0.52.1
+    privileged: true
+    devices:
+      - /dev/kmsg:/dev/kmsg
+    volumes:
+      - /:/rootfs:ro
+      - /var/run:/var/run:ro
+      - /sys:/sys:ro
+      - /var/lib/docker:/var/lib/docker:ro
+    logging: *observability-logging
+    restart: unless-stopped
+
+  blackbox-exporter:
+    image: quay.io/prometheus/blackbox-exporter:v0.27.0
+    command: ["--config.file=/etc/blackbox_exporter/config.yml"]
+    volumes:
+      - ./observability/prometheus/blackbox.yml:/etc/blackbox_exporter/config.yml:ro
+    logging: *observability-logging
+    restart: unless-stopped
+
+volumes:
+  grafana-data:
+  prometheus-data:
+  loki-data:
+  alloy-data:

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -1,0 +1,174 @@
+# Observability
+
+Первая итерация добавляет self-hosted стек Grafana OSS, Prometheus, Loki и
+Grafana Alloy как удаляемый Compose overlay. Код приложения, основной Compose,
+Nginx и lifecycle-команды не меняются.
+
+## Архитектура
+
+- **Grafana** автоматически получает Prometheus/Loki datasources и три dashboard;
+- **Prometheus** хранит host/container/runtime metrics и вычисляет alert rules;
+- **Loki** хранит технические container logs;
+- **Alloy** обнаруживает Docker containers и передаёт их stdout/stderr в Loki;
+- **node_exporter** публикует CPU, RAM, load и filesystem metrics хоста;
+- **cAdvisor** публикует container state и resource usage;
+- **blackbox_exporter** проверяет существующий `http://frontend:8080/health/ready`.
+
+Prometheus endpoint в Yii не добавляется. `audit_events`, `request_transitions` и
+`notification_outbox` являются application/business data и не заменяются Loki.
+Loki предназначен для технических runtime/application logs.
+
+Все сервисы находятся в default network того же Compose project. Prometheus,
+Loki, Alloy и exporters не публикуют ports на host. Grafana — единственный новый
+published port, по умолчанию `127.0.0.1:3000`; это безопасная точка для SSH
+tunnel или локального reverse proxy, но не готовый публичный production URL.
+
+Alloy получает read-only доступ к `/var/run/docker.sock`, а cAdvisor — read-only
+host mounts и `privileged` для container accounting. Это чувствительные
+операционные полномочия: доступ к их контейнерам и внутренней сети должен быть
+ограничен администраторами сервера.
+
+Стандартный nginx access log содержит request URI. Перед отправкой в Loki Alloy
+заменяет 64-символьный token в существующем
+`/api/v1/document-links/<token>/download` на `[REDACTED]`. Authorization headers,
+cookies и request body штатный nginx log format не пишет. Приложению всё равно
+не следует передавать secrets через произвольные query parameters: такие URI
+могут попасть в access log без дополнительной redaction.
+
+## Конфигурация и запуск
+
+В защищённый `.env.dev` или `.env.prod` добавьте:
+
+```dotenv
+GRAFANA_ADMIN_USER=admin
+GRAFANA_ADMIN_PASSWORD=<long-random-secret>
+GRAFANA_PORT=3000
+PROMETHEUS_RETENTION=15d
+PROMETHEUS_RETENTION_SIZE=10GB
+```
+
+В Git не хранится пароль или production env. `GRAFANA_ADMIN_PASSWORD` обязателен;
+Compose прекратит запуск при его отсутствии. На одном сервере нельзя одновременно
+оставить default `GRAFANA_PORT` для dev и prod — одному из проектов назначьте
+другой loopback port.
+
+Сначала поднимите приложение штатной командой. Development:
+
+```sh
+make dev-up
+COMPOSE_ENV_FILE=.env.dev docker compose -p ic-dev --env-file .env.dev \
+  -f compose.yaml -f compose.dev.yaml -f compose.observability.yml \
+  up -d grafana prometheus loki alloy node-exporter cadvisor blackbox-exporter
+```
+
+Production (после обязательного штатного `make prod-up`):
+
+```sh
+make prod-up
+COMPOSE_ENV_FILE=.env.prod docker compose -p ic-prod --env-file .env.prod \
+  -f compose.yaml -f compose.observability.yml \
+  up -d grafana prometheus loki alloy node-exporter cadvisor blackbox-exporter
+```
+
+Проверка состояния:
+
+```sh
+COMPOSE_ENV_FILE=.env.prod docker compose -p ic-prod --env-file .env.prod \
+  -f compose.yaml -f compose.observability.yml ps
+COMPOSE_ENV_FILE=.env.prod docker compose -p ic-prod --env-file .env.prod \
+  -f compose.yaml -f compose.observability.yml \
+  exec -T grafana wget -q --spider http://127.0.0.1:3000/api/health
+```
+
+Grafana provisioning находится в `observability/grafana/provisioning`, dashboard
+JSON — в `observability/grafana/dashboards`, Prometheus alerts — в
+`observability/prometheus/rules.yml`. Alert rules видны через Prometheus
+datasource. Contact point намеренно не задан: SMTP/webhook credentials должны
+поступать из согласованного secret store на следующем этапе.
+
+## Данные и retention
+
+Named volumes `<project>_grafana-data`, `<project>_prometheus-data` и
+`<project>_loki-data` переживают container recreation. Alloy также использует
+`<project>_alloy-data` для collector state. Runtime data в working tree не
+пишутся.
+
+Loki хранит данные 14 дней (`336h`). Prometheus хранит не более 15 дней и не
+более 10 GB; срабатывает первый достигнутый предел. Это консервативный старт для
+одного сервера рядом с приложением. Значения Prometheus можно уменьшить через
+env; изменение retention не удаляет application data. Собственные Docker logs
+observability-сервисов ограничены тремя файлами по 10 MB на container. Rotation
+уже существующих application containers остаётся политикой Docker daemon и не
+переопределяется overlay.
+
+Для обновления сначала измените явно pinned image tag, проверьте release notes и
+config validators, затем выполните ту же `up -d` команду. Named volumes
+сохраняются. Перед несовместимым обновлением сделайте snapshot/backup этих
+volumes.
+
+## Остановка и полное удаление
+
+Остановить только observability, сохранив данные:
+
+```sh
+COMPOSE_ENV_FILE=.env.prod docker compose -p ic-prod --env-file .env.prod \
+  -f compose.yaml -f compose.observability.yml \
+  stop grafana prometheus loki alloy node-exporter cadvisor blackbox-exporter
+```
+
+Удалить observability containers без воздействия на application containers:
+
+```sh
+COMPOSE_ENV_FILE=.env.prod docker compose -p ic-prod --env-file .env.prod \
+  -f compose.yaml -f compose.observability.yml rm -f \
+  grafana prometheus loki alloy node-exporter cadvisor blackbox-exporter
+```
+
+Named volumes сохраняются. Для полного удаления данных после отдельного backup
+удалите **точно перечисленные** `<project>_grafana-data`,
+`<project>_prometheus-data`, `<project>_loki-data` и `<project>_alloy-data` через
+`docker volume rm`. Не используйте `compose down --volumes`: эта команда также
+удалит MariaDB и document volumes приложения. После удаления каталога
+`observability/` и `compose.observability.yml` исходный deployment остаётся
+функционально идентичным.
+
+## Dashboards и alerts
+
+- **Infrastructure overview**: observability targets, CPU, RAM, load,
+  filesystem, container visibility, CPU/RAM и starts/restarts;
+- **IC runtime overview**: `/health/ready`, probe latency, application container
+  visibility/resources и active alerts;
+- **IC logs**: Loki entry point с low-cardinality `environment`, `service` и
+  `container` labels для frontend/nginx, backend/PHP-FPM, scheduler, MariaDB и
+  observability containers данного `ic-dev`/`ic-prod` project. Значение `All`
+  в фильтрах выбирает только непустые labels, как требует Loki; доступны также
+  независимые фильтры по environment и service.
+
+Prometheus rules покрывают readiness, отсутствие application containers,
+недоступность observability scrape targets, filesystem/memory pressure и
+повторные container starts. Последний сигнал отражает изменения start timestamp,
+а не Docker restart counter: cAdvisor не предоставляет надёжный универсальный
+counter для всех Compose runtimes.
+
+## Ограничения и следующие этапы
+
+- Для production URL нужны согласованные DNS, TLS и минимальный reverse-proxy
+  location к loopback Grafana; существующий application nginx не изменён.
+- LDAP/OAuth и Grafana role mapping требуют отдельной security-интеграции.
+- Нужен contact point из корпоративного SMTP/webhook secret store и routing
+  policy; сейчас alerts вычисляются и видны в UI, но наружу не отправляются.
+- Docker socket и privileged cAdvisor требуют отдельного hardening review; при
+  необходимости их можно изолировать socket proxy с минимальным API allowlist.
+- В Docker Desktop/WSL bind mount `/var/lib/docker` может не соответствовать
+  storage root Docker daemon. В таком окружении cAdvisor scrape остаётся
+  доступен, но container series/Compose labels могут быть неполными; полноценную
+  проверку container panels и alerts нужно повторить на целевом Linux server.
+- Nginx не экспортирует Prometheus counters; текущая итерация использует только
+  readiness и container telemetry. Container stdout/stderr могут содержать те
+  данные, которые уже пишет приложение. Текущая конфигурация не добавляет
+  cookies, authorization headers, tokens, request IDs, usernames, URL paths или
+  message contents в labels.
+- Wave 2 отдельно добавит application metrics: HTTP request count/latency/5xx,
+  notification outbox pending/failed, worker health, document processing
+  failures, requests by status и request age. Это потребует backend design и не
+  входит в infrastructure-only итерацию.

--- a/observability/alloy/config.alloy
+++ b/observability/alloy/config.alloy
@@ -1,0 +1,59 @@
+logging {
+  level  = "info"
+  format = "logfmt"
+}
+
+discovery.docker "containers" {
+  host             = "unix:///var/run/docker.sock"
+  refresh_interval = "5s"
+}
+
+discovery.relabel "container_logs" {
+  targets = discovery.docker.containers.targets
+
+  rule {
+    source_labels = ["__meta_docker_container_name"]
+    regex         = "/(.*)"
+    target_label  = "container"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+    target_label  = "service"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    regex         = "ic-(.+)"
+    replacement   = "$1"
+    target_label  = "environment"
+  }
+
+  rule {
+    source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+    regex         = "ic-(dev|prod)"
+    action        = "keep"
+  }
+}
+
+loki.source.docker "containers" {
+  host             = "unix:///var/run/docker.sock"
+  targets          = discovery.relabel.container_logs.output
+  forward_to       = [loki.process.redact.receiver]
+  refresh_interval = "5s"
+}
+
+loki.process "redact" {
+  forward_to = [loki.write.local.receiver]
+
+  stage.replace {
+    expression = "(?P<download_token>/api/v1/document-links/[a-f0-9]{64}/download)"
+    replace    = "/api/v1/document-links/[REDACTED]/download"
+  }
+}
+
+loki.write "local" {
+  endpoint {
+    url = "http://loki:3100/loki/api/v1/push"
+  }
+}

--- a/observability/grafana/dashboards/ic-runtime-overview.json
+++ b/observability/grafana/dashboards/ic-runtime-overview.json
@@ -1,0 +1,24 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "graphTooltip": 1,
+  "panels": [
+    {"type": "stat", "title": "IC /health/ready", "id": 1, "gridPos": {"h": 6, "w": 6, "x": 0, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"mappings": [{"type": "value", "options": {"0": {"text": "DOWN", "color": "red"}, "1": {"text": "READY", "color": "green"}}}], "color": {"mode": "thresholds"}}}, "targets": [{"expr": "probe_success{job=\"blackbox\"}", "refId": "A"}]},
+    {"type": "stat", "title": "Readiness latency", "id": 2, "gridPos": {"h": 6, "w": 6, "x": 6, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "s"}}, "targets": [{"expr": "probe_duration_seconds{job=\"blackbox\"}", "refId": "A"}]},
+    {"type": "stat", "title": "IC containers visible", "id": 3, "gridPos": {"h": 6, "w": 6, "x": 12, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "count(container_last_seen{container_label_com_docker_compose_service=~\"frontend|backend|scheduler|mariadb\"})", "refId": "A"}]},
+    {"type": "stat", "title": "Active alerts", "id": 4, "gridPos": {"h": 6, "w": 6, "x": 18, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "count(ALERTS{alertstate=\"firing\"}) OR vector(0)", "refId": "A"}]},
+    {"type": "timeseries", "title": "Readiness history", "id": 5, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 6}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "probe_success{job=\"blackbox\"}", "legendFormat": "{{instance}}", "refId": "A"}]},
+    {"type": "table", "title": "Application container runtime state", "id": 6, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 6}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "container_last_seen{container_label_com_docker_compose_service=~\"frontend|backend|scheduler|mariadb\"}", "format": "table", "instant": true, "refId": "A"}]},
+    {"type": "timeseries", "title": "Application container CPU", "id": 7, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 14}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "sum by (container_label_com_docker_compose_service) (rate(container_cpu_usage_seconds_total{container_label_com_docker_compose_service=~\"frontend|backend|scheduler|mariadb\"}[5m]))", "legendFormat": "{{container_label_com_docker_compose_service}}", "refId": "A"}]},
+    {"type": "timeseries", "title": "Application container memory", "id": 8, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 14}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "bytes"}}, "targets": [{"expr": "sum by (container_label_com_docker_compose_service) (container_memory_working_set_bytes{container_label_com_docker_compose_service=~\"frontend|backend|scheduler|mariadb\"})", "legendFormat": "{{container_label_com_docker_compose_service}}", "refId": "A"}]}
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["ic", "runtime"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "IC runtime overview",
+  "uid": "ic-runtime",
+  "version": 1
+}

--- a/observability/grafana/dashboards/infrastructure-overview.json
+++ b/observability/grafana/dashboards/infrastructure-overview.json
@@ -1,0 +1,25 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "graphTooltip": 1,
+  "panels": [
+    {"type": "stat", "title": "Observability targets up", "id": 1, "gridPos": {"h": 5, "w": 6, "x": 0, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "sum(up{job=~\"prometheus|loki|alloy|node|cadvisor|blackbox-exporter\"})", "refId": "A"}]},
+    {"type": "gauge", "title": "Host CPU usage", "id": 2, "gridPos": {"h": 5, "w": 6, "x": 6, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}}, "targets": [{"expr": "100 * (1 - avg(rate(node_cpu_seconds_total{mode=\"idle\"}[5m])))", "refId": "A"}]},
+    {"type": "gauge", "title": "Host RAM usage", "id": 3, "gridPos": {"h": 5, "w": 6, "x": 12, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}}, "targets": [{"expr": "100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes)", "refId": "A"}]},
+    {"type": "stat", "title": "Host load (1m)", "id": 4, "gridPos": {"h": 5, "w": 6, "x": 18, "y": 0}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "node_load1", "refId": "A"}]},
+    {"type": "timeseries", "title": "Filesystem usage", "id": 5, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 5}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "percent", "min": 0, "max": 100}}, "targets": [{"expr": "100 * (1 - node_filesystem_avail_bytes{fstype!~\"tmpfs|overlay|squashfs\"} / node_filesystem_size_bytes{fstype!~\"tmpfs|overlay|squashfs\"})", "legendFormat": "{{mountpoint}}", "refId": "A"}]},
+    {"type": "timeseries", "title": "Container CPU", "id": 6, "gridPos": {"h": 8, "w": 12, "x": 12, "y": 5}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "percentunit"}}, "targets": [{"expr": "sum by (name) (rate(container_cpu_usage_seconds_total{name!=\"\"}[5m]))", "legendFormat": "{{name}}", "refId": "A"}]},
+    {"type": "timeseries", "title": "Container memory", "id": 7, "gridPos": {"h": 8, "w": 12, "x": 0, "y": 13}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "fieldConfig": {"defaults": {"unit": "bytes"}}, "targets": [{"expr": "container_memory_working_set_bytes{name!=\"\"}", "legendFormat": "{{name}}", "refId": "A"}]},
+    {"type": "table", "title": "Container state and last seen", "id": 8, "gridPos": {"h": 8, "w": 8, "x": 12, "y": 13}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "container_last_seen{name!=\"\"}", "format": "table", "instant": true, "refId": "A"}]},
+    {"type": "stat", "title": "Starts/restarts in 30m", "id": 9, "gridPos": {"h": 8, "w": 4, "x": 20, "y": 13}, "datasource": {"type": "prometheus", "uid": "prometheus"}, "targets": [{"expr": "sum(changes(container_start_time_seconds{name!=\"\"}[30m]))", "refId": "A"}]}
+  ],
+  "refresh": "30s",
+  "schemaVersion": 41,
+  "tags": ["ic", "infrastructure"],
+  "templating": {"list": []},
+  "time": {"from": "now-6h", "to": "now"},
+  "timezone": "browser",
+  "title": "Infrastructure overview",
+  "uid": "ic-infrastructure",
+  "version": 1
+}

--- a/observability/grafana/dashboards/logs.json
+++ b/observability/grafana/dashboards/logs.json
@@ -1,0 +1,19 @@
+{
+  "annotations": {"list": []},
+  "editable": false,
+  "panels": [
+    {"type": "logs", "title": "IC technical logs", "id": 1, "gridPos": {"h": 14, "w": 24, "x": 0, "y": 0}, "datasource": {"type": "loki", "uid": "loki"}, "options": {"showTime": true, "showLabels": true, "wrapLogMessage": true, "enableLogDetails": true, "sortOrder": "Descending"}, "targets": [{"expr": "{environment=~\"$environment\", service=~\"$service\"}", "refId": "A"}]}
+  ],
+  "refresh": "10s",
+  "schemaVersion": 41,
+  "tags": ["ic", "logs"],
+  "templating": {"list": [
+    {"name": "environment", "label": "Environment", "type": "query", "datasource": {"type": "loki", "uid": "loki"}, "query": "label_values(environment)", "includeAll": true, "allValue": ".+", "current": {"text": "All", "value": "$__all"}},
+    {"name": "service", "label": "Service", "type": "query", "datasource": {"type": "loki", "uid": "loki"}, "query": "label_values({environment=~\"$environment\"}, service)", "includeAll": true, "allValue": ".+", "current": {"text": "All", "value": "$__all"}}
+  ]},
+  "time": {"from": "now-1h", "to": "now"},
+  "timezone": "browser",
+  "title": "IC logs",
+  "uid": "ic-logs",
+  "version": 1
+}

--- a/observability/grafana/provisioning/dashboards/dashboards.yml
+++ b/observability/grafana/provisioning/dashboards/dashboards.yml
@@ -1,0 +1,13 @@
+apiVersion: 1
+
+providers:
+  - name: IC observability
+    orgId: 1
+    folder: IC
+    type: file
+    disableDeletion: true
+    allowUiUpdates: false
+    updateIntervalSeconds: 30
+    options:
+      path: /var/lib/grafana/dashboards
+      foldersFromFilesStructure: false

--- a/observability/grafana/provisioning/datasources/datasources.yml
+++ b/observability/grafana/provisioning/datasources/datasources.yml
@@ -1,0 +1,25 @@
+apiVersion: 1
+
+deleteDatasources:
+  - name: Prometheus
+    orgId: 1
+  - name: Loki
+    orgId: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: false
+    jsonData:
+      timeInterval: 15s
+
+  - name: Loki
+    uid: loki
+    type: loki
+    access: proxy
+    url: http://loki:3100
+    editable: false

--- a/observability/loki/config.yml
+++ b/observability/loki/config.yml
@@ -1,0 +1,38 @@
+auth_enabled: false
+
+server:
+  http_listen_port: 3100
+
+common:
+  path_prefix: /loki
+  storage:
+    filesystem:
+      chunks_directory: /loki/chunks
+      rules_directory: /loki/rules
+  replication_factor: 1
+  ring:
+    kvstore:
+      store: inmemory
+
+schema_config:
+  configs:
+    - from: 2024-01-01
+      store: tsdb
+      object_store: filesystem
+      schema: v13
+      index:
+        prefix: index_
+        period: 24h
+
+compactor:
+  working_directory: /loki/compactor
+  retention_enabled: true
+  delete_request_store: filesystem
+
+limits_config:
+  retention_period: 336h
+  max_query_lookback: 336h
+  allow_structured_metadata: true
+
+analytics:
+  reporting_enabled: false

--- a/observability/prometheus/blackbox.yml
+++ b/observability/prometheus/blackbox.yml
@@ -1,0 +1,8 @@
+modules:
+  http_ic_ready:
+    prober: http
+    timeout: 5s
+    http:
+      method: GET
+      preferred_ip_protocol: ip4
+      valid_status_codes: [200]

--- a/observability/prometheus/prometheus.yml
+++ b/observability/prometheus/prometheus.yml
@@ -1,0 +1,45 @@
+global:
+  scrape_interval: 15s
+  evaluation_interval: 15s
+
+rule_files:
+  - /etc/prometheus/rules.yml
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: [prometheus:9090]
+
+  - job_name: loki
+    static_configs:
+      - targets: [loki:3100]
+
+  - job_name: alloy
+    static_configs:
+      - targets: [alloy:12345]
+
+  - job_name: node
+    static_configs:
+      - targets: [node-exporter:9100]
+
+  - job_name: cadvisor
+    static_configs:
+      - targets: [cadvisor:8080]
+
+  - job_name: blackbox
+    metrics_path: /probe
+    params:
+      module: [http_ic_ready]
+    static_configs:
+      - targets: [http://frontend:8080/health/ready]
+    relabel_configs:
+      - source_labels: [__address__]
+        target_label: __param_target
+      - source_labels: [__param_target]
+        target_label: instance
+      - target_label: __address__
+        replacement: blackbox-exporter:9115
+
+  - job_name: blackbox-exporter
+    static_configs:
+      - targets: [blackbox-exporter:9115]

--- a/observability/prometheus/rules.yml
+++ b/observability/prometheus/rules.yml
@@ -1,0 +1,83 @@
+groups:
+  - name: observability
+    rules:
+      - alert: ICReadinessUnavailable
+        expr: probe_success{job="blackbox"} == 0
+        for: 2m
+        labels:
+          severity: critical
+        annotations:
+          summary: IC readiness endpoint is unavailable
+          description: The existing /health/ready path has failed for more than two minutes.
+
+      - alert: ObservabilityTargetUnavailable
+        expr: up{job=~"prometheus|loki|alloy|node|cadvisor|blackbox-exporter"} == 0
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Observability target {{ $labels.job }} is unavailable
+          description: Prometheus has not scraped {{ $labels.instance }} successfully for five minutes.
+
+      - alert: ICFrontendContainerMissing
+        expr: absent(container_last_seen{container_label_com_docker_compose_service="frontend"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: IC frontend container is missing
+          description: cAdvisor cannot see the expected frontend Compose service.
+
+      - alert: ICBackendContainerMissing
+        expr: absent(container_last_seen{container_label_com_docker_compose_service="backend"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: IC backend container is missing
+          description: cAdvisor cannot see the expected backend Compose service.
+
+      - alert: ICSchedulerContainerMissing
+        expr: absent(container_last_seen{container_label_com_docker_compose_service="scheduler"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: IC scheduler container is missing
+          description: cAdvisor cannot see the expected scheduler Compose service.
+
+      - alert: ICDatabaseContainerMissing
+        expr: absent(container_last_seen{container_label_com_docker_compose_service="mariadb"})
+        for: 5m
+        labels:
+          severity: critical
+        annotations:
+          summary: IC database container is missing
+          description: cAdvisor cannot see the expected MariaDB Compose service.
+
+      - alert: HostFilesystemAlmostFull
+        expr: 100 * (1 - node_filesystem_avail_bytes{fstype!~"tmpfs|overlay|squashfs"} / node_filesystem_size_bytes{fstype!~"tmpfs|overlay|squashfs"}) > 85
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Filesystem usage is above 85 percent
+          description: Filesystem {{ $labels.mountpoint }} on {{ $labels.instance }} is nearly full.
+
+      - alert: HostMemoryPressure
+        expr: 100 * (1 - node_memory_MemAvailable_bytes / node_memory_MemTotal_bytes) > 90
+        for: 15m
+        labels:
+          severity: warning
+        annotations:
+          summary: Host memory usage is above 90 percent
+          description: Available host memory has remained below 10 percent for 15 minutes.
+
+      - alert: RepeatedContainerRestarts
+        expr: changes(container_start_time_seconds{container_label_com_docker_compose_service!=""}[30m]) > 2
+        for: 5m
+        labels:
+          severity: warning
+        annotations:
+          summary: Container {{ $labels.name }} restarted repeatedly
+          description: The container start timestamp changed more than twice in 30 minutes.

--- a/observability/tests/test_logs_dashboard.py
+++ b/observability/tests/test_logs_dashboard.py
@@ -1,0 +1,56 @@
+import json
+import re
+import unittest
+from pathlib import Path
+
+
+DASHBOARD = (
+    Path(__file__).parents[1] / "grafana" / "dashboards" / "logs.json"
+)
+MATCHER = re.compile(r'\w+=~"([^"]*)"')
+
+
+class LogsDashboardTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        cls.dashboard = json.loads(DASHBOARD.read_text(encoding="utf-8"))
+        cls.variables = {
+            variable["name"]: variable
+            for variable in cls.dashboard["templating"]["list"]
+        }
+        cls.expression = cls.dashboard["panels"][0]["targets"][0]["expr"]
+
+    def test_all_values_do_not_match_empty_strings(self):
+        for name in ("environment", "service"):
+            pattern = self.variables[name]["allValue"]
+            with self.subTest(variable=name):
+                self.assertIsNone(
+                    re.fullmatch(pattern, ""),
+                    f"{name} All value must not match an empty string",
+                )
+
+    def test_supported_filter_combinations_have_a_non_empty_matcher(self):
+        all_environment = self.variables["environment"]["allValue"]
+        all_service = self.variables["service"]["allValue"]
+        combinations = (
+            (all_environment, all_service),
+            ("dev", all_service),
+            (all_environment, "backend"),
+            ("dev", "backend"),
+        )
+
+        for environment, service in combinations:
+            expression = self.expression.replace(
+                "$environment", environment
+            ).replace("$service", service)
+            patterns = MATCHER.findall(expression)
+            with self.subTest(environment=environment, service=service):
+                self.assertTrue(patterns, "LogQL selector must contain matchers")
+                self.assertTrue(
+                    any(re.fullmatch(pattern, "") is None for pattern in patterns),
+                    f"LogQL selector is empty-compatible: {expression}",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,8 +6,8 @@ sonar.python.version=3.13
 
 sonar.sources=.
 sonar.tests=.
-sonar.test.inclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,scripts/tests/**
-sonar.exclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,scripts/tests/**,backend/vendor/**,frontend/node_modules/**,frontend/dist/**,frontend/coverage/**,backend/build/**,artifacts/**,prototype/**,**/*.png,**/*.woff2,**/*.pdf
+sonar.test.inclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,scripts/tests/**,observability/tests/**
+sonar.exclusions=backend/tests/**,frontend/**/*.test.js,frontend/e2e/**,scripts/tests/**,observability/tests/**,backend/vendor/**,frontend/node_modules/**,frontend/dist/**,frontend/coverage/**,backend/build/**,artifacts/**,prototype/**,**/*.png,**/*.woff2,**/*.pdf
 
 sonar.php.coverage.reportPaths=backend/build/coverage/clover.xml
 sonar.python.coverage.reportPaths=backend/build/coverage/python.xml


### PR DESCRIPTION
## Summary

- adds a removable Docker Compose observability overlay with Grafana OSS, Prometheus, Loki, Grafana Alloy, node_exporter, cAdvisor, and blackbox_exporter;
- provisions Prometheus and Loki datasources, infrastructure/runtime/log dashboards, and Prometheus alert rules entirely from version-controlled configuration;
- keeps Grafana bound to loopback while Prometheus, Loki, Alloy, and exporters remain internal to the Compose network;
- persists Grafana, Prometheus, Loki, and Alloy state in named volumes and bounds retention to 15 days / 10 GB for Prometheus and 14 days for Loki;
- collects Docker stdout/stderr through Alloy and redacts document download tokens before forwarding logs to Loki.

The overlay does not duplicate or modify application services. Removing `compose.observability.yml` and `observability/` leaves the existing deployment behavior unchanged.

## Application isolation

- backend changed: no
- frontend changed: no
- DB schema changed: no
- API changed: no
- business logic changed: no

## Verification

- `make check`: passed (264 frontend tests, production build, PHPStan, dependency audits, 468 PHPUnit tests / 938 assertions, architecture guard, repository contracts);
- observability focused tests: 2 passed;
- combined development Compose `config --quiet`: passed;
- Grafana dashboard JSON validation: passed;
- Prometheus config and 9 rules: valid;
- Loki config verification: passed;
- Alloy config validation: passed;
- `git diff --check`: passed;
- runtime smoke: Grafana/Prometheus/Loki/cAdvisor healthy; Alloy/exporters running; all seven Prometheus targets up;
- Prometheus and Loki Grafana datasource health checks: passed;
- `/health/ready`: READY and `probe_success=1`;
- Logs dashboard selectors `All/All`, `dev/All`, `All/backend`, and `dev/backend`: successful with no Loki selector HTTP 400;
- logs arrive in Loki and download-token redaction remains observable.

## Follow-up backlog

The following issues are intentionally not closed by this infrastructure-only PR:

- #294 Yii cache configuration;
- #295 environment-aware notification delivery policy;
- #296 production SQL parameter logging;
- #297 source-level download-token logging;
- #298 production Grafana DNS/TLS/reverse proxy;
- #299 corporate Grafana authentication;
- #300 alert delivery and routing;
- #301 cAdvisor verification on the target Linux host;
- #302 Docker observability privilege hardening;
- #303 Wave 2 technical application metrics;
- #304 business and operational metrics discovery.

## Known deployment boundary

Production publication and authentication are deliberately deferred. Grafana currently listens only on `127.0.0.1:${GRAFANA_PORT}`, and no internal observability endpoint is published externally.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a self-hosted observability stack with metrics, logs, container monitoring, and endpoint health checks.
  * Added Grafana dashboards for runtime health, infrastructure, and searchable logs.
  * Added alerts for readiness failures, unavailable services, resource pressure, and repeated container restarts.
  * Added persistent storage, retention controls, health checks, and log redaction.

* **Documentation**
  * Added setup, configuration, verification, maintenance, and limitations guidance for observability.

* **Tests**
  * Added validation for log dashboard filters and queries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->