### PR TITLE
fix(nginx): маскировать download token в access log

### DIFF
--- a/compose.test.yaml
+++ b/compose.test.yaml
@@ -91,6 +91,31 @@ services:
       start_period: 15s
     restart: unless-stopped
 
+  loki:
+    image: docker.io/grafana/loki:3.5.3
+    command: ["-config.file=/etc/loki/config.yml"]
+    volumes:
+      - ./observability/loki/config.yml:/etc/loki/config.yml:ro
+    tmpfs: ["/loki:uid=10001,gid=10001"]
+    healthcheck:
+      test: ["CMD-SHELL", "wget -q --spider http://127.0.0.1:3100/ready"]
+      interval: 2s
+      timeout: 3s
+      retries: 30
+
+  alloy:
+    image: docker.io/grafana/alloy:v1.10.0
+    command:
+      - run
+      - --storage.path=/var/lib/alloy/data
+      - /etc/alloy/config.alloy
+    volumes:
+      - ./observability/alloy/config.test.alloy:/etc/alloy/config.alloy:ro
+      - /var/run/docker.sock:/var/run/docker.sock:ro
+    tmpfs: [/var/lib/alloy/data]
+    depends_on:
+      loki: {condition: service_healthy}
+
 volumes:
   test-mariadb-data:
   test-document-data:

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -3,9 +3,14 @@ map $request_uri $source_access_request_uri {
     "~^/api/v1/document-links/[a-f0-9]{64}/download(?:\\?|$)" /api/v1/document-links/[masked]/download;
 }
 
+map $http_referer $source_access_referer {
+    default $http_referer;
+    "~^.*?/api/v1/document-links/[a-f0-9]{64}/download(?:[?#].*)?$" /api/v1/document-links/[masked]/download;
+}
+
 log_format source_access '$remote_addr - $remote_user [$time_local] '
                          '"$request_method $source_access_request_uri $server_protocol" $status $body_bytes_sent '
-                         '"$http_referer" "$http_user_agent"';
+                         '"$source_access_referer" "$http_user_agent" request_time=$request_time';
 
 server {
     listen 8080;

--- a/docker/nginx/default.conf
+++ b/docker/nginx/default.conf
@@ -1,3 +1,12 @@
+map $request_uri $source_access_request_uri {
+    default $request_uri;
+    "~^/api/v1/document-links/[a-f0-9]{64}/download(?:\\?|$)" /api/v1/document-links/[masked]/download;
+}
+
+log_format source_access '$remote_addr - $remote_user [$time_local] '
+                         '"$request_method $source_access_request_uri $server_protocol" $status $body_bytes_sent '
+                         '"$http_referer" "$http_user_agent"';
+
 server {
     listen 8080;
     server_name _;
@@ -9,6 +18,8 @@ server {
     # proxy, иначе запрос не дойдёт до прикладной проверки 200 МБ
     # (COM-007/DOC-002A).
     client_max_body_size 256m;
+
+    access_log /var/log/nginx/access.log source_access;
 
     add_header X-Content-Type-Options nosniff always;
     add_header X-Frame-Options DENY always;

--- a/observability/alloy/config.test.alloy
+++ b/observability/alloy/config.test.alloy
@@ -1,0 +1,46 @@
+logging {
+	level  = "info"
+	format = "logfmt"
+}
+
+discovery.docker "test_containers" {
+	host             = "unix:///var/run/docker.sock"
+	refresh_interval = "1s"
+}
+
+discovery.relabel "test_container_logs" {
+	targets = discovery.docker.test_containers.targets
+
+	rule {
+		source_labels = ["__meta_docker_container_label_com_docker_compose_service"]
+		target_label  = "service"
+	}
+
+	rule {
+		source_labels = ["__meta_docker_container_label_com_docker_compose_project"]
+		regex         = "ic-test"
+		action        = "keep"
+	}
+}
+
+loki.source.docker "test_containers" {
+	host             = "unix:///var/run/docker.sock"
+	targets          = discovery.relabel.test_container_logs.output
+	forward_to       = [loki.process.redact.receiver]
+	refresh_interval = "1s"
+}
+
+loki.process "redact" {
+	forward_to = [loki.write.test.receiver]
+
+	stage.replace {
+		expression = "(?P<download_token>/api/v1/document-links/[a-f0-9]{64}/download)"
+		replace    = "/api/v1/document-links/[REDACTED]/download"
+	}
+}
+
+loki.write "test" {
+	endpoint {
+		url = "http://loki:3100/loki/api/v1/push"
+	}
+}

--- a/scripts/check-deployment-contracts.sh
+++ b/scripts/check-deployment-contracts.sh
@@ -175,12 +175,32 @@ grep -Fq 'map $request_uri $source_access_request_uri {' docker/nginx/default.co
 grep -Fq '"~^/api/v1/document-links/[a-f0-9]{64}/download(?:\\?|$)" /api/v1/document-links/[masked]/download;' docker/nginx/default.conf
 # shellcheck disable=SC2016 # These are literal nginx variable contracts.
 grep -Fq '"$request_method $source_access_request_uri $server_protocol"' docker/nginx/default.conf
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+grep -Fq 'map $http_referer $source_access_referer {' docker/nginx/default.conf
+grep -Fq '"~^.*?/api/v1/document-links/[a-f0-9]{64}/download(?:[?#].*)?$" /api/v1/document-links/[masked]/download;' docker/nginx/default.conf
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+grep -Fq '"$source_access_referer" "$http_user_agent" request_time=$request_time' docker/nginx/default.conf
 grep -Fq 'access_log /var/log/nginx/access.log source_access;' docker/nginx/default.conf
 # shellcheck disable=SC2016 # These are literal nginx variable contracts.
-if grep -Eq 'log_format[^;]*(\$request|\$request_uri)([^_a-zA-Z]|$)' docker/nginx/default.conf; then
+source_access_format=$(awk '
+  /^log_format source_access[[:space:]]/ { collecting = 1 }
+  collecting { printf "%s ", $0 }
+  collecting && /;/ { exit }
+' docker/nginx/default.conf)
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+if printf '%s\n' "$source_access_format" | grep -Eq '(\$request|\$request_uri)([^_a-zA-Z]|$)'; then
   echo 'Nginx source access log must use the sanitized request URI.' >&2
   exit 1
 fi
+# Prove that the guard rejects a forbidden variable on a continuation line.
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+unsafe_source_access_format=$(printf '%s\n' "$source_access_format" | sed 's/\$source_access_request_uri/\$request_uri/')
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+printf '%s\n' "$unsafe_source_access_format" | grep -Eq '(\$request|\$request_uri)([^_a-zA-Z]|$)'
+for alloy_config in observability/alloy/config.alloy observability/alloy/config.test.alloy; do
+  grep -Fq 'expression = "(?P<download_token>/api/v1/document-links/[a-f0-9]{64}/download)"' "$alloy_config"
+  grep -Fq 'replace    = "/api/v1/document-links/[REDACTED]/download"' "$alloy_config"
+done
 grep -Fxq 'upload_max_filesize=200M' docker/php/uploads.ini
 grep -Fxq 'post_max_size=210M' docker/php/uploads.ini
 

--- a/scripts/check-deployment-contracts.sh
+++ b/scripts/check-deployment-contracts.sh
@@ -170,6 +170,17 @@ done
 grep -Fq 'location = /api/openapi.yaml' docker/nginx/default.conf
 grep -Fq 'location ^~ /api/docs/' docker/nginx/default.conf
 grep -Fq 'client_max_body_size 256m;' docker/nginx/default.conf
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+grep -Fq 'map $request_uri $source_access_request_uri {' docker/nginx/default.conf
+grep -Fq '"~^/api/v1/document-links/[a-f0-9]{64}/download(?:\\?|$)" /api/v1/document-links/[masked]/download;' docker/nginx/default.conf
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+grep -Fq '"$request_method $source_access_request_uri $server_protocol"' docker/nginx/default.conf
+grep -Fq 'access_log /var/log/nginx/access.log source_access;' docker/nginx/default.conf
+# shellcheck disable=SC2016 # These are literal nginx variable contracts.
+if grep -Eq 'log_format[^;]*(\$request|\$request_uri)([^_a-zA-Z]|$)' docker/nginx/default.conf; then
+  echo 'Nginx source access log must use the sanitized request URI.' >&2
+  exit 1
+fi
 grep -Fxq 'upload_max_filesize=200M' docker/php/uploads.ini
 grep -Fxq 'post_max_size=210M' docker/php/uploads.ini
 

--- a/scripts/e2e.sh
+++ b/scripts/e2e.sh
@@ -7,6 +7,13 @@ cd "$project_root"
 : "${TEST_ENV_FILE:?TEST_ENV_FILE must be provided by Makefile}"
 compose="$COMPOSE -p $TEST_PROJECT --env-file $TEST_ENV_FILE -f compose.test.yaml"
 . scripts/compose-metadata.sh
+
+redact_download_tokens() {
+  sed -E \
+    -e 's#(/api/v1/document-links/)[a-f0-9]{64}(/download)#\1[REDACTED]\2#g' \
+    -e 's#((download_token|token)=)[a-f0-9]{64}#\1[REDACTED]#g'
+}
+
 cleanup() {
   status=$?
   cd "$project_root"
@@ -15,7 +22,7 @@ cleanup() {
     diagnostics=frontend/playwright-report/deployment
     mkdir -p "$diagnostics"
     $compose ps >"$diagnostics/ps.txt" 2>&1 || true
-    $compose logs --tail=200 >"$diagnostics/logs.txt" 2>&1 || true
+    $compose logs --tail=200 2>&1 | redact_download_tokens >"$diagnostics/logs.txt" || true
   fi
   sh scripts/test-env.sh destroy || true
   return "$status"
@@ -23,6 +30,14 @@ cleanup() {
 trap cleanup EXIT
 trap 'exit 130' INT
 trap 'exit 143' TERM
+artifact_probe_token=aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa
+artifact_probe=$(printf '/api/v1/document-links/%s/download?token=%s safe-marker\n' \
+  "$artifact_probe_token" "$artifact_probe_token" | redact_download_tokens)
+printf '%s' "$artifact_probe" | grep -Fq 'safe-marker'
+if printf '%s' "$artifact_probe" | grep -Fq "$artifact_probe_token"; then
+  echo 'Deployment diagnostics redaction contract failed.' >&2
+  exit 1
+fi
 sh scripts/test-env.sh build
 sh scripts/test-env.sh up
 if [ -z "${TEST_BASE_URL:-}" ]; then

--- a/scripts/test-runtime-contracts.sh
+++ b/scripts/test-runtime-contracts.sh
@@ -4,12 +4,21 @@ cd "$(CDPATH='' cd -- "$(dirname -- "$0")/.." && pwd)"
 : "${COMPOSE:?COMPOSE must be provided by Makefile}"
 : "${TEST_PROJECT:?TEST_PROJECT must be provided by Makefile}"
 : "${TEST_ENV_FILE:?TEST_ENV_FILE must be provided by Makefile}"
+[ "$TEST_PROJECT" = ic-test ] || {
+  echo 'Runtime contracts require TEST_PROJECT=ic-test.' >&2
+  exit 2
+}
+[ "$TEST_ENV_FILE" = .env.test ] || {
+  echo 'Runtime contracts require TEST_ENV_FILE=.env.test.' >&2
+  exit 2
+}
 compose="$COMPOSE -p $TEST_PROJECT --env-file $TEST_ENV_FILE -f compose.test.yaml"
 : "${TEST_BASE_URL:?TEST_BASE_URL must be provided by e2e.sh}"
 base=$TEST_BASE_URL
 : "${MAILPIT_BASE_URL:?MAILPIT_BASE_URL must be provided by e2e.sh}"
 mailpit=$MAILPIT_BASE_URL
 cookie_jar=$(mktemp)
+download_token_hash=
 
 curl_with_timeout() {
   curl --connect-timeout 3 --max-time 10 "$@"
@@ -19,6 +28,9 @@ restore_services() {
   status=$?
   trap - EXIT INT TERM
   $compose start ad mailpit mariadb scheduler >/dev/null 2>&1 || true
+  if [ -n "$download_token_hash" ]; then
+    db_query "DELETE FROM document_download_links WHERE token_hash='$download_token_hash'" >/dev/null 2>&1 || true
+  fi
   rm -f "$cookie_jar"
   exit "$status"
 }
@@ -153,23 +165,53 @@ create_request() {
 }
 
 echo "Проверка маскирования download token в source access log"
-download_token=2972972972972972972972972972972972972972972972972972972972972972
+download_token=$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')
+invalid_download_token=$(node -e 'process.stdout.write(require("node:crypto").randomBytes(32).toString("hex"))')
 ordinary_log_marker=issue-297-safe-query
 download_token_hash=$(node -e 'process.stdout.write(require("node:crypto").createHash("sha256").update(process.argv[1]).digest("hex"))' "$download_token")
 download_version_id=$(db_query 'SELECT id FROM request_document_versions WHERE deleted_at IS NULL ORDER BY id LIMIT 1')
 [ -n "$download_version_id" ]
 db_query "INSERT INTO document_download_links (document_version_id, token_hash, created_at) VALUES ($download_version_id, '$download_token_hash', CURRENT_TIMESTAMP(6))"
+$compose up -d loki alloy >/dev/null
+sleep 2
 download_code=$(curl_with_timeout -sS -o /dev/null -w '%{http_code}' \
+  -H "Referer: https://portal.invalid/api/v1/document-links/$download_token/download?token=$download_token" \
   "$base/api/v1/document-links/$download_token/download?download_token=$download_token&trace=$ordinary_log_marker")
 [ "$download_code" = 200 ]
-curl_with_timeout -fsS "$base/health/live?trace=$ordinary_log_marker" >/dev/null
+invalid_download_code=$(curl_with_timeout -sS -o /dev/null -w '%{http_code}' \
+  "$base/api/v1/document-links/$invalid_download_token/download?token=$invalid_download_token")
+[ "$invalid_download_code" = 404 ]
+safe_referer="https://portal.invalid/requests?trace=$ordinary_log_marker"
+curl_with_timeout -fsS -H "Referer: $safe_referer" "$base/health/live?trace=$ordinary_log_marker" >/dev/null
 frontend_logs=$($compose logs frontend)
-if printf '%s' "$frontend_logs" | grep -Fq "$download_token"; then
+if printf '%s' "$frontend_logs" | grep -Eq "$download_token|$invalid_download_token"; then
   echo 'Raw download token leaked into the frontend access log.' >&2
   exit 1
 fi
 printf '%s' "$frontend_logs" | grep -Fq 'GET /api/v1/document-links/[masked]/download HTTP/1.1" 200'
+printf '%s' "$frontend_logs" | grep -Fq 'GET /api/v1/document-links/[masked]/download HTTP/1.1" 404'
+printf '%s' "$frontend_logs" | grep -Fq '"/api/v1/document-links/[masked]/download"'
 printf '%s' "$frontend_logs" | grep -Fq "GET /health/live?trace=$ordinary_log_marker HTTP/1.1\" 200"
+printf '%s' "$frontend_logs" | grep -Fq "\"$safe_referer\""
+printf '%s' "$frontend_logs" | grep -Eq 'request_time=[0-9]+\.[0-9]+'
+
+loki_query='http://127.0.0.1:3100/loki/api/v1/query_range?query=%7Bservice%3D%22frontend%22%7D&limit=500'
+loki_attempt=0
+until loki_logs=$($compose exec -T loki wget -qO- "$loki_query") &&
+  printf '%s' "$loki_logs" | grep -Fq 'GET /api/v1/document-links/[masked]/download HTTP/1.1'; do
+  loki_attempt=$((loki_attempt + 1))
+  [ "$loki_attempt" -lt 30 ] || {
+    echo 'Masked download request did not reach Loki.' >&2
+    exit 1
+  }
+  sleep 1
+done
+if printf '%s' "$loki_logs" | grep -Eq "$download_token|$invalid_download_token"; then
+  echo 'Raw download token leaked into Loki.' >&2
+  exit 1
+fi
+db_query "DELETE FROM document_download_links WHERE token_hash='$download_token_hash'"
+download_token_hash=
 
 echo "Проверка восстановления SMTP и повторной отправки"
 curl_with_timeout -fsS -X DELETE "$mailpit/api/v1/messages" >/dev/null

--- a/scripts/test-runtime-contracts.sh
+++ b/scripts/test-runtime-contracts.sh
@@ -152,6 +152,25 @@ create_request() {
     "$base/api/v1/requests"
 }
 
+echo "Проверка маскирования download token в source access log"
+download_token=2972972972972972972972972972972972972972972972972972972972972972
+ordinary_log_marker=issue-297-safe-query
+download_token_hash=$(node -e 'process.stdout.write(require("node:crypto").createHash("sha256").update(process.argv[1]).digest("hex"))' "$download_token")
+download_version_id=$(db_query 'SELECT id FROM request_document_versions WHERE deleted_at IS NULL ORDER BY id LIMIT 1')
+[ -n "$download_version_id" ]
+db_query "INSERT INTO document_download_links (document_version_id, token_hash, created_at) VALUES ($download_version_id, '$download_token_hash', CURRENT_TIMESTAMP(6))"
+download_code=$(curl_with_timeout -sS -o /dev/null -w '%{http_code}' \
+  "$base/api/v1/document-links/$download_token/download?download_token=$download_token&trace=$ordinary_log_marker")
+[ "$download_code" = 200 ]
+curl_with_timeout -fsS "$base/health/live?trace=$ordinary_log_marker" >/dev/null
+frontend_logs=$($compose logs frontend)
+if printf '%s' "$frontend_logs" | grep -Fq "$download_token"; then
+  echo 'Raw download token leaked into the frontend access log.' >&2
+  exit 1
+fi
+printf '%s' "$frontend_logs" | grep -Fq 'GET /api/v1/document-links/[masked]/download HTTP/1.1" 200'
+printf '%s' "$frontend_logs" | grep -Fq "GET /health/live?trace=$ordinary_log_marker HTTP/1.1\" 200"
+
 echo "Проверка восстановления SMTP и повторной отправки"
 curl_with_timeout -fsS -X DELETE "$mailpit/api/v1/messages" >/dev/null
 $compose stop mailpit


### PR DESCRIPTION
## Цель

Закрывает #297: исключить raw download token из production nginx source access log без отключения журнала и потери диагностируемого пути.

## Что изменено

- Root cause: raw download token попадал в nginx access log через `$request`.
- Для `/api/v1/document-links/<token>/download` token локально заменяется на `[masked]`; метод, безопасная часть path, protocol, status и остальные диагностические поля сохраняются.
- Query string чувствительного download request не журналируется, поэтому token не может повторно попасть в лог через query.
- Обычные запросы логируются без изменения.
- Runtime-регрессия подтверждает HTTP 200, отсутствие raw token в access log, сохранение безопасного path и прежний формат обычного запроса.

## Связанные правила и задачи

- Closes #297.

## Проверка

- `make check` — passed: 318 frontend tests, 468 backend tests, PHPStan, lint, audits, production build и repository/deployment contracts.
- `make e2e` — passed: 311 integration tests, 16 Playwright tests и runtime contracts.
- `nginx -t` на production nginx 1.29.4 image — passed.
- После обновления `origin/main` rebase не потребовался; deployment contracts, `nginx -t` и push-hook `make check` повторно прошли.
- Независимый read-only Codex review итогового change set — findings отсутствуют.

## Риски и откат

Изменение ограничено source access logging frontend nginx и не меняет маршрутизацию, передачу `REQUEST_URI`, авторизацию или скачивание. Откат — revert единственного commit.

## Метки

- [x] назначена ровно одна метка `type:*`;
- [x] назначены все применимые метки `area:*`;
- [x] назначена ровно одна метка `risk:*`;
- [x] `dependencies` и `breaking-change` не применимы.

## Готовность

- [ ] тесты и обязательный pipeline проходят;
- [x] выполнен независимый read-only Codex review итогового change set: findings отсутствуют, checks после последнего implementation-прохода повторены; <!-- review-contract:final-change-set -->
- [ ] Qodo завершил проверку текущего head-коммита;
- [x] документация и пользовательские инструкции не требуют изменения: пользовательский контракт не менялся;
- [x] миграции отсутствуют;
- [x] секреты и персональные данные не попали в код и логи.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Security & Privacy**
  - Download links containing access tokens are now masked in server access logs, reducing the risk of sensitive tokens being exposed.
  - Standard query information remains available for troubleshooting while protected download credentials are concealed.

- **Reliability**
  - Added automated deployment and runtime checks to verify secure log handling and confirm downloads continue to work correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->