### PR TITLE
fix(logging): исключить SQL bind values из production logs

### DIFF
--- a/backend/composer.json
+++ b/backend/composer.json
@@ -16,7 +16,7 @@
     "dompdf/dompdf": "^3.1",
     "phpoffice/phpword": "^1.4",
     "symfony/mailer": "^7.0",
-    "yiisoft/yii2": "^2.0"
+    "yiisoft/yii2": "^2.0.35"
   },
   "require-dev": {
     "phpstan/phpstan": "^2.1",

--- a/backend/composer.lock
+++ b/backend/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "2bd5c363986386c3418824b16ce6f92c",
+    "content-hash": "e50f16d289429073497374c95a2c3c34",
     "packages": [
         {
             "name": "cebe/markdown",

--- a/backend/config/common.php
+++ b/backend/config/common.php
@@ -51,6 +51,7 @@ return [
     'components' => [
         'db' => [
             'class' => yii\db\Connection::class,
+            'commandClass' => App\Infrastructure\Logging\ParameterSafeCommand::class,
             'dsn' => sprintf(
                 'mysql:host=%s;port=%s;dbname=%s',
                 $env('DB_HOST', 'mariadb'),

--- a/backend/src/Infrastructure/Logging/ParameterSafeCommand.php
+++ b/backend/src/Infrastructure/Logging/ParameterSafeCommand.php
@@ -1,0 +1,41 @@
+<?php
+
+declare(strict_types=1);
+
+namespace App\Infrastructure\Logging;
+
+use Yii;
+use yii\db\Command;
+use yii\db\Exception;
+
+/**
+ * Keeps bind parameter values out of query, profile, and DB exception messages.
+ */
+final class ParameterSafeCommand extends Command
+{
+    /** @return array{bool, string|null} */
+    protected function logQuery($category): array
+    {
+        $sql = $this->getSql();
+        if ($this->db->enableLogging) {
+            Yii::info($sql, $category);
+        }
+
+        return [$this->db->enableProfiling, $sql];
+    }
+
+    protected function internalExecute($rawSql): void
+    {
+        try {
+            parent::internalExecute($rawSql);
+        } catch (Exception $error) {
+            $errorClass = $error::class;
+            $sqlState = isset($error->errorInfo[0]) ? (string) $error->errorInfo[0] : 'unknown';
+            $driverCode = isset($error->errorInfo[1]) ? (string) $error->errorInfo[1] : 'unknown';
+            $message = "Database query failed (SQLSTATE {$sqlState}, driver code {$driverCode})."
+                . "\nThe SQL being executed was: {$rawSql}";
+
+            throw new $errorClass($message, [$sqlState, $driverCode], $driverCode);
+        }
+    }
+}

--- a/backend/tests/Integration/Logging/SqlLoggingContractTest.php
+++ b/backend/tests/Integration/Logging/SqlLoggingContractTest.php
@@ -1,0 +1,107 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Integration\Logging;
+
+use App\Infrastructure\Logging\ParameterSafeCommand;
+use Tests\Integration\IntegrationTestCase;
+use Yii;
+use yii\db\Command;
+use yii\db\Exception;
+use yii\log\Logger;
+
+final class SqlLoggingContractTest extends IntegrationTestCase
+{
+    private string $previousCommandClass;
+    private Logger $previousLogger;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousCommandClass = $this->db()->commandClass;
+        $this->previousLogger = Yii::getLogger();
+        Yii::setLogger(new Logger(['flushInterval' => 1000]));
+    }
+
+    protected function tearDown(): void
+    {
+        $this->db()->commandClass = $this->previousCommandClass;
+        Yii::setLogger($this->previousLogger);
+        parent::tearDown();
+    }
+
+    public function testProductionQueryCommandProfilingAndErrorKeepTemplatesWithoutValues(): void
+    {
+        $secret = 'sql-log-secret-' . bin2hex(random_bytes(12));
+        $this->db()->commandClass = ParameterSafeCommand::class;
+
+        self::assertSame($secret, $this->db()->createCommand(
+            'SELECT :query_secret',
+            [':query_secret' => $secret],
+        )->queryScalar());
+        self::assertSame(0, $this->db()->createCommand(
+            'UPDATE {{%users}} SET display_name = display_name WHERE ad_login = :command_secret',
+            [':command_secret' => $secret],
+        )->execute());
+
+        $insert = 'INSERT INTO {{%users}} '
+            . '(ad_login, display_name, is_active, created_at, updated_at) '
+            . 'VALUES (:error_secret, :display_name, 1, NOW(6), NOW(6))';
+        $this->db()->createCommand($insert, [
+            ':error_secret' => $secret,
+            ':display_name' => 'SQL logging contract',
+        ])->execute();
+
+        try {
+            $this->db()->createCommand($insert, [
+                ':error_secret' => $secret,
+                ':display_name' => 'Duplicate SQL logging contract',
+            ])->execute();
+            self::fail('The duplicate unique value must fail.');
+        } catch (Exception $error) {
+            Yii::error($error, 'sql.logging.contract');
+        }
+
+        $log = $this->technicalLog();
+        self::assertStringContainsString('SELECT :query_secret', $log);
+        self::assertStringContainsString('UPDATE `users`', $log);
+        self::assertStringContainsString(':command_secret', $log);
+        self::assertStringContainsString('INSERT INTO `users`', $log);
+        self::assertStringContainsString(':error_secret', $log);
+        self::assertStringContainsString('SQLSTATE 23000, driver code 1062', $log);
+        self::assertStringContainsString('[info][yii\\db\\Command::query]', $log);
+        self::assertStringContainsString('[profile begin][yii\\db\\Command::query]', $log);
+        self::assertStringContainsString('[profile end][yii\\db\\Command::query]', $log);
+        self::assertStringContainsString('[error][sql.logging.contract]', $log);
+        self::assertStringNotContainsString($secret, $log);
+    }
+
+    public function testDiagnosticYiiCommandStillIncludesBindValues(): void
+    {
+        $secret = 'sql-log-dev-secret-' . bin2hex(random_bytes(12));
+        $this->db()->commandClass = Command::class;
+
+        self::assertSame($secret, $this->db()->createCommand(
+            'SELECT :diagnostic_secret',
+            [':diagnostic_secret' => $secret],
+        )->queryScalar());
+
+        self::assertStringContainsString($secret, $this->technicalLog());
+    }
+
+    private function technicalLog(): string
+    {
+        $lines = [];
+        foreach (Yii::getLogger()->messages as $message) {
+            $lines[] = sprintf(
+                '[%s][%s] %s',
+                Logger::getLevelName($message[1]),
+                $message[2],
+                is_string($message[0]) ? $message[0] : (string) $message[0],
+            );
+        }
+
+        return implode("\n", $lines);
+    }
+}

--- a/backend/tests/Unit/Infrastructure/Logging/SqlLoggingConfigurationTest.php
+++ b/backend/tests/Unit/Infrastructure/Logging/SqlLoggingConfigurationTest.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Tests\Unit\Infrastructure\Logging;
+
+use App\Infrastructure\Logging\ParameterSafeCommand;
+use PHPUnit\Framework\TestCase;
+
+final class SqlLoggingConfigurationTest extends TestCase
+{
+    private string|false $previousPassword;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->previousPassword = getenv('DB_PASSWORD');
+        putenv('DB_PASSWORD=configuration-test-password');
+    }
+
+    protected function tearDown(): void
+    {
+        $this->previousPassword === false
+            ? putenv('DB_PASSWORD')
+            : putenv('DB_PASSWORD=' . $this->previousPassword);
+        parent::tearDown();
+    }
+
+    public function testProductionUsesParameterSafeCommand(): void
+    {
+        $config = require dirname(__DIR__, 4) . '/config/common.php';
+
+        self::assertSame(ParameterSafeCommand::class, $config['components']['db']['commandClass']);
+    }
+}

--- a/deployment/dev/console.php
+++ b/deployment/dev/console.php
@@ -3,6 +3,11 @@
 declare(strict_types=1);
 
 return [
+    'components' => [
+        'db' => [
+            'commandClass' => yii\db\Command::class,
+        ],
+    ],
     'controllerMap' => [
         'dev' => App\Console\DevController::class,
     ],

--- a/deployment/dev/web.php
+++ b/deployment/dev/web.php
@@ -5,6 +5,9 @@ declare(strict_types=1);
 return [
     'params' => ['identityHeader' => 'X-Dev-User-ID'],
     'components' => [
+        'db' => [
+            'commandClass' => yii\db\Command::class,
+        ],
         'urlManager' => [
             'rules' => [
                 'GET health/logging' => 'health/logging',

--- a/deployment/test/console.php
+++ b/deployment/test/console.php
@@ -3,6 +3,11 @@
 declare(strict_types=1);
 
 return [
+    'components' => [
+        'db' => [
+            'commandClass' => yii\db\Command::class,
+        ],
+    ],
     'controllerMap' => [
         'test' => App\Console\TestController::class,
     ],

--- a/deployment/test/web.php
+++ b/deployment/test/web.php
@@ -4,4 +4,9 @@ declare(strict_types=1);
 
 return [
     'params' => ['identityHeader' => 'X-Test-User-ID'],
+    'components' => [
+        'db' => [
+            'commandClass' => yii\db\Command::class,
+        ],
+    ],
 ];


### PR DESCRIPTION
Closes #296

## Что изменено

- Root cause: Yii `Command::logQuery()` подставлял bind values через `getRawSql()`; значения также могли попадать в DB exceptions.
- Решение: production `ParameterSafeCommand` логирует SQL template без bind values и sanitizes exception context, сохраняя SQLSTATE и driver code.
- Dev/test сохраняют стандартный `yii\db\Command`.
- Проверены query, execute, profiling и DB error paths.

## Проверки

- MariaDB integration contract: 2 tests, 15 assertions — passed.
- `make check`: passed (backend 469 tests / 939 assertions; frontend 318 tests; PHPStan, lint, audits, production build и repository contracts).
- Pre-push `make check`: passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved production SQL logging to preserve parameter placeholders and prevent sensitive bound values from appearing in logs.
  * Enhanced database error messages with standardized SQLSTATE, driver code, and query details.

* **Tests**
  * Added coverage for safe SQL logging across queries, profiling, updates, and database errors.
  * Added configuration checks for production and diagnostic database command behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->