### PR TITLE
fix(ci): восстановить сбор container logs в GitLab e2e

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ e2e:
   image: mcr.microsoft.com/playwright:v1.62.0-noble
   services:
     - name: docker:29.0.0-dind
-      command: ["dockerd", "--tls=false", "--host=tcp://0.0.0.0:2375"]
+      command: ["dockerd", "--tls=false", "--host=tcp://0.0.0.0:2375", "--host=unix:///var/run/docker.sock"]
   variables:
     DOCKER_HOST: tcp://docker:2375
     DOCKER_TLS_CERTDIR: ""


### PR DESCRIPTION
## Проблема

GitLab e2e использует Docker-in-Docker через `DOCKER_HOST=tcp://docker:2375`, однако test Alloy читает container logs через `/var/run/docker.sock`. DinD был запущен только с TCP listener, поэтому bind mount socket внутри Alloy указывал на несуществующий endpoint и runtime contract не находил masked download request в Loki.

## Решение

Только для e2e service DinD добавлен второй listener `unix:///var/run/docker.sock`. TCP listener и текущий `DOCKER_HOST=tcp://docker:2375` сохранены. Product/local Compose и конфигурации Alloy/Loki не изменяются.

## Проверка

- dual-host DinD: TCP `docker info` и read-only Unix socket внутри контейнера работают;
- GitLab e2e: 16 Playwright tests и все runtime contracts, включая masked download → Loki, прошли;
- `make check`: успешно (469 backend tests / 939 assertions, 318 frontend tests, build, PHPStan, audits и repository contracts).

## Риск и откат

Изменение ограничено командой GitLab e2e DinD service. Откат — revert единственного коммита.